### PR TITLE
Fix sync builds toggle not updating visual tick

### DIFF
--- a/src/app/components/Header.jsx
+++ b/src/app/components/Header.jsx
@@ -259,6 +259,7 @@ export default class Header extends TranslatedComponent {
    */
   _toggleSyncBuilds() {
     Persist.syncBuilds(!Persist.syncBuilds());
+    this.forceUpdate();
   }
 
   /**


### PR DESCRIPTION
Added forceUpdate() after toggling syncBuilds so the checkmark updates immediately without needing to close and reopen the settings menu.