### PR TITLE
Fix crash when clicking builds button with no saved builds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+#4.0.24
+  * Builds Button on Firefox fix when no builds saved
 #4.0.23
   * Ensuring the Advanced Planetary Approach Suite is added to imported ships for consistency
 #4.0.22

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coriolis_shipyard",
-  "version": "4.0.23",
+  "version": "4.0.24",
   "repository": {
     "type": "git",
     "url": "https://github.com/EDCD/coriolis"

--- a/src/app/stores/Persist.js
+++ b/src/app/stores/Persist.js
@@ -381,7 +381,7 @@ export class Persist extends EventEmitter {
    * @return {Boolean} True if any builds have been saved
    */
   hasBuilds() {
-    return Object.keys(this.builds).length > 0;
+    return this.builds && Object.keys(this.builds).length > 0;
   }
 
   /**


### PR DESCRIPTION
Guard hasBuilds() against this.builds being null/undefined when the localStorage key doesn't exist, preventing the erratic potential error on first visit before any builds are created.