### PR TITLE
Fix imported ships missing Advanced Planetary Approach Suite

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+#4.0.23
+  * Ensuring the Advanced Planetary Approach Suite is added to imported ships for consistency
 #4.0.22
   * Auto Select Module Search on Available Modules Menu opening
 #4.0.21

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coriolis_shipyard",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "repository": {
     "type": "git",
     "url": "https://github.com/EDCD/coriolis"

--- a/src/app/utils/CompanionApiUtils.js
+++ b/src/app/utils/CompanionApiUtils.js
@@ -429,6 +429,13 @@ export function shipFromJson(json) {
 
     if (!internalSlot) {
       // This can happen with old imports that don't contain new slots
+      // Default PAS slot to Advanced Planetary Approach Suite (Odyssey)
+      if (slotName === 'PlanetaryApproachSuite') {
+        let apas = _moduleFromEdId(128975719);
+        if (apas) {
+          ship.use(ship.internal[i], apas, true);
+        }
+      }
     } else if (!internalSlot.module) {
       // No module
     } else {

--- a/src/app/utils/JournalUtils.js
+++ b/src/app/utils/JournalUtils.js
@@ -355,6 +355,13 @@ export function shipFromLoadoutJSON(json) {
 
     if (!internalSlot) {
       // This can happen with old imports that don't contain new slots
+      // Default PAS slot to Advanced Planetary Approach Suite (Odyssey)
+      if (isPlanetary) {
+        let apas = _moduleFromFdName('int_planetapproachsuite_advanced');
+        if (apas) {
+          ship.use(ship.internal[i], apas, true);
+        }
+      }
     } else {
       const internalJson = internalSlot;
       let internal = _moduleFromFdName(internalJson.Item);


### PR DESCRIPTION
## Summary
When importing ships from EDSY or other third-party tools, the Advanced Planetary Approach Suite (Odyssey) was not being added to the ship. This is because these tools don't include the PAS in their export data since it's a mandatory fixed module.

## Changes
- **JournalUtils.js**: When the PAS slot is not found in import data, default to Advanced Planetary Approach Suite (Odyssey)
- **CompanionApiUtils.js**: Same fix for the Companion API import path

## Testing
- Imported an EDSY build that previously showed an empty PAS slot
- Confirmed the Advanced Planetary Approach Suite now appears correctly after import
