### PR TITLE
Auto-focus module search box on desktop when opening slot

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+#4.0.22
+  * Auto Select Module Search on Available Modules Menu opening
 #4.0.21
   * Fixing layout issue on module selection menu
 #4.0.20

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coriolis_shipyard",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "repository": {
     "type": "git",
     "url": "https://github.com/EDCD/coriolis"

--- a/src/app/components/AvailableModulesMenu.jsx
+++ b/src/app/components/AvailableModulesMenu.jsx
@@ -1736,6 +1736,7 @@ export default class AvailableModulesMenu extends TranslatedComponent {
               value={searchQuery}
               onChange={this._handleSearchChange}
               onClick={(e) => e.stopPropagation()}
+              autoFocus={this.context.noTouch}
             />
           </div>
         )}

--- a/src/app/components/CategoryMenu.jsx
+++ b/src/app/components/CategoryMenu.jsx
@@ -338,6 +338,7 @@ export default class CategoryMenu extends TranslatedComponent {
               value={searchQuery}
               onChange={this._handleSearchChange}
               onClick={(e) => e.stopPropagation()}
+              autoFocus={this.context.noTouch}
             />
           </div>
           <AvailableModulesMenuWithSearch
@@ -369,6 +370,7 @@ export default class CategoryMenu extends TranslatedComponent {
             value={searchQuery}
             onChange={this._handleSearchChange}
             onClick={(e) => e.stopPropagation()}
+            autoFocus={this.context.noTouch}
           />
         </div>
 
@@ -412,6 +414,10 @@ class AvailableModulesMenuWithSearch extends AvailableModulesMenu {
 
   componentDidMount() {
     super.componentDidMount();
+    // Auto-focus search input on desktop (not mobile, to avoid keyboard popup)
+    if (this.context.noTouch && this.searchInputRef.current) {
+      this.searchInputRef.current.focus();
+    }
     // Trigger search filtering after mount
     if (this.props.searchQuery) {
       this._filterModulesBySearch();


### PR DESCRIPTION
## Summary
When clicking a module slot on desktop, the search box now auto-focuses so you can immediately start typing to filter modules.

## Changes
- Added autoFocus (gated by noTouch) to search inputs in AvailableModulesMenu and CategoryMenu
- Works for all slot types: optional internals, hardpoints, and utility mounts
- Does not trigger on mobile/touch devices to avoid unwanted keyboard popup