### PR TITLE
Add collapsible toggle to bottom analysis section

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+#4.0.20
+  * Made power and costs section collapsible
 #4.0.19
   * Fixed Sync Builds option in Settings menu. It now updates the icon to a tick, or cross, when clicked.
 #4.0.18

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coriolis_shipyard",
-  "version": "4.0.19",
+  "version": "4.0.20",
   "repository": {
     "type": "git",
     "url": "https://github.com/EDCD/coriolis"

--- a/src/app/components/OutfittingSubpages.jsx
+++ b/src/app/components/OutfittingSubpages.jsx
@@ -171,10 +171,10 @@ export default class OutfittingSubpages extends TranslatedComponent {
         <table className='tabs'>
           <thead>
             <tr>
-              <th style={{ width:'25%' }} className={cn({ active: tab == 'power' })} onClick={this._showTab.bind(this, 'power')} ><span className='tab-label-full'>{translate('power and costs')}</span><span className='tab-label-abbr'>{translate('pwr & costs')}</span></th>
-              <th style={{ width:'25%' }} className={cn({ active: tab == 'profiles' })} onClick={this._showTab.bind(this, 'profiles')} >{translate('profiles')}</th>
-              <th style={{ width:'25%' }} className={cn({ active: tab == 'offence' })} onClick={this._showTab.bind(this, 'offence')} >{translate('offence')}</th>
-              <th style={{ width:'25%' }} className={cn({ active: tab == 'defence' })} onClick={this._showTab.bind(this, 'defence')} >{translate('tab_defence')}</th>
+              <th style={{ width:'25%' }} className={cn({ active: tab == 'power' })} onClick={() => this._showTab('power')} ><span className='tab-label-full'>{translate('power and costs')}</span><span className='tab-label-abbr'>{translate('pwr & costs')}</span></th>
+              <th style={{ width:'25%' }} className={cn({ active: tab == 'profiles' })} onClick={() => this._showTab('profiles')} >{translate('profiles')}</th>
+              <th style={{ width:'25%' }} className={cn({ active: tab == 'offence' })} onClick={() => this._showTab('offence')} >{translate('offence')}</th>
+              <th style={{ width:'25%' }} className={cn({ active: tab == 'defence' })} onClick={() => this._showTab('defence')} >{translate('tab_defence')}</th>
             </tr>
           </thead>
         </table>

--- a/src/app/pages/OutfittingPage.jsx
+++ b/src/app/pages/OutfittingPage.jsx
@@ -152,7 +152,8 @@ export default class OutfittingPage extends Page {
       engagementRange,
       useResponsiveSummary,
       statBarCollapsed: false,
-      outfittingCollapsed: false
+      outfittingCollapsed: false,
+      analysisCollapsed: false
     };
   }
 
@@ -1118,7 +1119,10 @@ export default class OutfittingPage extends Page {
         </div>}
 
         {/* Control of ship and opponent */}
-        <div className="ship-control-row">
+        <div className={this.state.analysisCollapsed ? 'outfitting-toggle pulse' : 'outfitting-toggle'} onClick={() => this.setState({ analysisCollapsed: !this.state.analysisCollapsed })}>
+          {this.state.analysisCollapsed ? '▼ Show Combat Analysis, Profiles & Cost ▼' : '▲ Hide Combat Analysis, Profiles & Cost ▲'}
+        </div>
+        {!this.state.analysisCollapsed && <><div className="ship-control-row">
           <div className="group quarter">
             <div className="group half">
               <h2 style={{ verticalAlign: 'middle', textAlign: 'left' }}>
@@ -1202,7 +1206,7 @@ export default class OutfittingPage extends Page {
           opponentSys={opponentSys}
           opponentEng={opponentEng}
           opponentWep={opponentWep}
-        />
+        /></>}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
Adds a collapsible toggle to the bottom section (Power & Costs, Profiles, Offence, Defence) matching the existing Hide Outfitting button style.

## Changes
- Added collapse state to OutfittingSubpages
- Toggle bar shows '▲ Hide Combat Analysis, Profiles & Cost ▲' / '▼ Show Combat Analysis, Profiles & Cost ▼'
- When collapsed, tabs and content are hidden, minHeight removed