### PR TITLE
Overhaul announcement system

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+#4.0.25
+  * Revamped Announcements and created Changelog page
 #4.0.24
   * Builds Button on Firefox fix when no builds saved
 #4.0.23

--- a/generate-announcements.js
+++ b/generate-announcements.js
@@ -1,0 +1,46 @@
+/**
+ * generate-announcements.js
+ * 
+ * Reads ChangeLog.md and package.json to generate src/app/data/announcements.json
+ * Run at build time or as part of the promotion workflow.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const changelogPath = path.join(__dirname, 'ChangeLog.md');
+const outputPath = path.join(__dirname, 'src', 'app', 'data', 'announcements.json');
+
+const changelog = fs.readFileSync(changelogPath, 'utf8');
+
+// Parse changelog entries: #X.Y.Z followed by bullet points
+const entries = [];
+const sections = changelog.split(/^#(?=\d)/m).filter(Boolean);
+
+sections.forEach((section, index) => {
+  const lines = section.trim().split('\n');
+  const version = lines[0].trim();
+  const bullets = lines.slice(1)
+    .map(l => l.replace(/^\s*\*\s*/, '').trim())
+    .filter(Boolean);
+
+  if (version && bullets.length > 0) {
+    entries.push({
+      id: sections.length - index,
+      version: version,
+      text: bullets[0], // First bullet as the tagline
+      changes: bullets
+    });
+  }
+});
+
+// Output all entries (announcements modal shows last 7, changelog shows all)
+const announcements = entries;
+
+// Ensure output directory exists
+const outputDir = path.dirname(outputPath);
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}
+
+fs.writeFileSync(outputPath, JSON.stringify(announcements, null, 2));
+console.log(`Generated ${announcements.length} announcements from ChangeLog.md`);

--- a/generate-announcements.js
+++ b/generate-announcements.js
@@ -1,6 +1,6 @@
 /**
  * generate-announcements.js
- * 
+ *
  * Reads ChangeLog.md and package.json to generate src/app/data/announcements.json
  * Run at build time or as part of the promotion workflow.
  */
@@ -24,13 +24,21 @@ sections.forEach((section, index) => {
     .filter(Boolean);
 
   if (version && bullets.length > 0) {
-    entries.push({
-      id: sections.length - index,
-      version: version,
-      text: bullets[0], // First bullet as the tagline
-      changes: bullets
-    });
-  }
+    // Split version into major, minor, patch, using . as the separator
+    const parts = version.split('.');
+    const major = parseInt(parts[0], 10);
+    const minor = parseInt(parts[1], 10);
+    const patch = parseInt(parts[2], 10);
+    // Only include announcements from version 4.0.9 onwards
+    if (major > 4 || (major === 4 && minor > 0) || (major === 4 && minor === 0 && patch >= 9)) {
+      entries.push({
+        id: sections.length - index,
+        version: version,
+        text: bullets[0], // First bullet as the tagline
+        changes: bullets
+      });
+    };
+  };
 });
 
 // Output all entries (announcements modal shows last 7, changelog shows all)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coriolis_shipyard",
-  "version": "4.0.24",
+  "version": "4.0.25",
   "repository": {
     "type": "git",
     "url": "https://github.com/EDCD/coriolis"

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
   "scripts": {
     "extract-translations": "grep -hroE \"(translate\\('[^']+'\\))|(tip.bind\\(null, '[^']+')\" src/* | grep -oE \"'[^']+'\" | grep -oE \"[^']+\" | sort -u -f",
     "clean": "rimraf build",
-    "start": "node generate-ship-mappings.js && node devServer.js",
+    "start": "node generate-ship-mappings.js && node generate-announcements.js && node devServer.js",
     "start:prod": "webpack serve --config webpack.config.prod.js",
     "lint": "eslint --ext .js,.jsx src",
     "test": "jest",
     "prod-serve": "nginx -p $(pwd) -c nginx.conf",
     "prod-stop": "kill -QUIT $(cat nginx.pid)",
     "buildfresh": "rimraf node_modules && rm package-lock.json && npm install && npm run build > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)",
-    "build": "node generate-ship-mappings.js && webpack --config webpack.config.prod.js",
+    "build": "node generate-ship-mappings.js && node generate-announcements.js && webpack --config webpack.config.prod.js",
     "rsync": "rsync -ae \"ssh -i $CORIOLIS_PEM\" --delete build/ $CORIOLIS_USER@$CORIOLIS_HOST:~/wwws",
     "deploy": "npm run lint && npm test && npm run build && npm run rsync"
   },

--- a/src/app/Coriolis.jsx
+++ b/src/app/Coriolis.jsx
@@ -8,6 +8,8 @@ import { getLanguage } from './i18n/Language';
 import Persist from './stores/Persist';
 
 import Announcement from './components/Announcement';
+import AnnouncementBanner from './components/AnnouncementBanner';
+import announcementsData from './data/announcements.json';
 import Header from './components/Header';
 import Tooltip from './components/Tooltip';
 import ModalExport from './components/ModalExport';
@@ -17,6 +19,7 @@ import ModalPermalink from './components/ModalPermalink';
 import * as CompanionApiUtils from './utils/CompanionApiUtils';
 import * as JournalUtils from './utils/JournalUtils';
 import AboutPage from './pages/AboutPage';
+import ChangelogPage from './pages/ChangelogPage';
 import NotFoundPage from './pages/NotFoundPage';
 import OutfittingPage from './pages/OutfittingPage';
 import ComparisonPage from './pages/ComparisonPage';
@@ -55,13 +58,23 @@ export default class Coriolis extends React.Component {
     this.state = {
       noTouch: !('ontouchstart' in window || navigator.msMaxTouchPoints || navigator.maxTouchPoints),
       page: null,
-      // Announcements must have an expiry date in format "YYYY-MM-DDTHH:MM:SSZ"
-      announcements: [{expiry: "2026-04-28T00:00:00Z", text: "Lynx Highliner added!"}],
+      // Announcements loaded from generated data (see generate-announcements.js)
+      announcements: announcementsData,
+      showAnnouncementBanner: false,
 
       language: getLanguage(Persist.getLangCode()),
       route: {},
       sizeRatio: Persist.getSizeRatio()
     };
+
+    // Show banner for newest announcement if not already seen
+    const validAnnouncements = this.state.announcements.slice(0, 7);
+    if (validAnnouncements.length > 0) {
+      const lastSeenId = parseInt(localStorage.getItem('lastSeenAnnouncementId') || '0');
+      if (validAnnouncements[0].id > lastSeenId) {
+        this.state.showAnnouncementBanner = true;
+      }
+    }
     Router('', (r) => this._setPage(ShipyardPage, r));
     Router('/import?', (r) => this._importBuild(r));
     Router('/import/:data', (r) => this._importBuild(r));
@@ -72,6 +85,7 @@ export default class Coriolis extends React.Component {
     Router('/comparison?', (r) => this._setPage(ComparisonPage, r));
     Router('/comparison/:code', (r) => this._setPage(ComparisonPage, r));
     Router('/about', (r) => this._setPage(AboutPage, r));
+    Router('/changelog', (r) => this._setPage(ChangelogPage, r));
     Router('*', (r) => this._setPage(null, r));
   }
 
@@ -468,11 +482,17 @@ export default class Coriolis extends React.Component {
       <AppContext.Provider value={contextValue}>
         <div style={{ minHeight: '100%' }} onClick={() => { this._closeMenu(); this._tooltip(); }}
              className={this.state.noTouch ? 'no-touch' : null}>
-          <Header announcements={this.state.announcements} appCacheUpdate={this.state.appCacheUpdate}
+          <Header announcements={this.state.announcements} hasUnseenAnnouncements={this.state.showAnnouncementBanner} appCacheUpdate={this.state.appCacheUpdate}
+                  onAnnouncementsSeen={() => {
+                    if (this.state.announcements.length > 0) localStorage.setItem('lastSeenAnnouncementId', this.state.announcements[0].id.toString());
+                    this.setState({ showAnnouncementBanner: false });
+                  }}
                   currentMenu={currentMenu}/>
-          <div className="announcement-container">{this.state.announcements.map((a, index) => <Announcement
-            key={index}
-            text={a.text}/>)}</div>
+          <div className="announcement-container"></div>
+          {this.state.showAnnouncementBanner && <AnnouncementBanner
+            announcement={this.state.announcements[0]}
+            onDismiss={() => this.setState({ showAnnouncementBanner: false })}
+          />}
           {this.state.error ? this.state.error : this.state.page ? React.createElement(this.state.page, { currentMenu }) :
             <NotFoundPage/>}
           {this.state.modal}

--- a/src/app/components/AnnouncementBanner.jsx
+++ b/src/app/components/AnnouncementBanner.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Announcement Banner - slides down from top, auto-dismisses after 15s
+ * Sets localStorage after 4s so quick navigations still show it again
+ */
+export default class AnnouncementBanner extends React.Component {
+
+  static propTypes = {
+    announcement: PropTypes.object,
+    onDismiss: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { hiding: false };
+  }
+
+  componentDidMount() {
+    // Mark as seen after 4 seconds
+    this._cookieTimer = setTimeout(() => {
+      if (this.props.announcement) {
+        localStorage.setItem('lastSeenAnnouncementId', this.props.announcement.id.toString());
+      }
+    }, 4000);
+
+    // Start slide-up animation at 14.7s, dismiss at 15s
+    this._hideTimer = setTimeout(() => {
+      this.setState({ hiding: true });
+    }, 14700);
+
+    this._dismissTimer = setTimeout(() => {
+      this.props.onDismiss();
+    }, 15000);
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this._cookieTimer);
+    clearTimeout(this._hideTimer);
+    clearTimeout(this._dismissTimer);
+  }
+
+  render() {
+    const { announcement } = this.props;
+    if (!announcement) return null;
+
+    return (
+      <div className="announcement-banner-overlay">
+        <div className={`announcement-banner ${this.state.hiding ? 'slide-up' : ''}`}>
+          {(() => { const h = window.location.hostname; const p = h.includes('alpha') ? 'Alpha v' : h.includes('beta') ? 'Beta v' : 'v'; return p; })()}{announcement.version} — {announcement.text}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/app/components/Header.jsx
+++ b/src/app/components/Header.jsx
@@ -6,7 +6,8 @@ import { Insurance } from '../shipyard/Constants';
 import Link from './Link';
 import ActiveLink from './ActiveLink';
 import cn from 'classnames';
-import { Cogs, CoriolisLogo, Hammer, Heart, Help, PersonIcon, Rocket, StatsBars } from './SvgIcons';
+import { Bell, Cogs, CoriolisLogo, Hammer, Heart, Help, PersonIcon, Rocket, StatsBars } from './SvgIcons';
+import ModalAnnouncements from './ModalAnnouncements';
 import { Ships } from 'coriolis-data/dist';
 import Persist from '../stores/Persist';
 import { toDetailedExport } from '../shipyard/Serializer';
@@ -443,24 +444,23 @@ export default class Header extends TranslatedComponent {
    * @return {React.Component} Menu
    */
   _getAnnouncementsMenu() {
-    let announcements;
+    let announcements = [];
     let translate = this.context.language.translate;
 
     if (this.props.announcements) {
-      announcements = [];
-      for (let announce of this.props.announcements) {
-        // Announcement has expired, skip it
-        if (Date.now() > Date.parse(announce.expiry)) {
-          continue;
-        }
-        // Add announcements which have not expired to the menu
-        announcements.push(<Announcement text={announce.text} />);
-        announcements.push(<hr/>);
+      for (let i = 0; i < Math.min(this.props.announcements.length, 7); i++) {
+        let announce = this.props.announcements[i];
+        announcements.push(
+          <div key={i} className='announcement-item'>
+            {announce.text}
+          </div>
+        );
       }
     }
+
     return (
-      <div className='menu-list' onClick={ (e) => e.stopPropagation() } style={{ whiteSpace: 'nowrap' }}>
-        {announcements}
+      <div className='menu-list announcement-menu' onClick={ (e) => e.stopPropagation() }>
+        {announcements.length > 0 ? announcements : <div className='announcement-item'>{translate('none')}</div>}
       </div>
     );
   }
@@ -631,30 +631,29 @@ export default class Header extends TranslatedComponent {
 
         <div className='l menu'>
           <div className={cn('menu-header', { selected: openedMenu == 's' })} onClick={this._openShips}>
-            <Rocket className='warning' /><span className='menu-item-label'>{translate('ships')}</span>
+            <Rocket className='warning md' /><span className='menu-item-label'>{translate('ships')}</span>
           </div>
           {openedMenu == 's' ? this._getShipsMenu() : null}
         </div>
 
         <div className='l menu'>
           <div className={cn('menu-header', { selected: openedMenu == 'b', disabled: !hasBuilds })} onClick={hasBuilds ? this._openBuilds : undefined}>
-            <Hammer className={cn('warning', { 'warning-disabled': !hasBuilds })} /><span className='menu-item-label'>{translate('builds')}</span>
+            <Hammer className={cn('warning md', { 'warning-disabled': !hasBuilds })} /><span className='menu-item-label'>{translate('builds')}</span>
           </div>
           {openedMenu == 'b' ? this._getBuildsMenu() : null}
         </div>
 
         <div className='l menu'>
           <div className={cn('menu-header', { selected: openedMenu == 'comp', disabled: !hasBuilds })} onClick={hasBuilds ? this._openComp : undefined}>
-            <StatsBars className={cn('warning', { 'warning-disabled': !hasBuilds })} /><span className='menu-item-label'>{translate('compare')}</span>
+            <StatsBars className={cn('warning md', { 'warning-disabled': !hasBuilds })} /><span className='menu-item-label'>{translate('compare')}</span>
           </div>
           {openedMenu == 'comp' ? this._getComparisonsMenu() : null}
         </div>
 
         <div className='l menu'>
-          <div className={cn('menu-header', { selected: openedMenu == 'announce', disabled: this.props.announcements.length === 0})} onClick={this.props.announcements.length !== 0 ? this._openAnnounce : undefined}>
-            <span className='menu-item-label'>{translate('announcements')}</span>
+          <div className={cn('menu-header', { selected: openedMenu == 'announce', disabled: this.props.announcements.length === 0, pulse: this.props.hasUnseenAnnouncements && openedMenu !== 'announce'})} onClick={this.props.announcements.length !== 0 ? (e) => { e.stopPropagation(); if (this.props.onAnnouncementsSeen) this.props.onAnnouncementsSeen(); this.context.showModal(<ModalAnnouncements announcements={this.props.announcements} />); } : undefined}>
+            <Bell className='warning md' /><span className='menu-item-label'>{translate('announcements')}</span>
           </div>
-          {openedMenu == 'announce' ? this._getAnnouncementsMenu() : null}
         </div>
 
         {window.location.origin.search('.edcd.io') >= 0 ?
@@ -669,27 +668,27 @@ export default class Header extends TranslatedComponent {
 
         <div className='r menu'>
           <div className={cn('menu-header')} onClick={this._showCmdr}>
-            <PersonIcon className={'xl' + (Persist.hasCmdrLinks() ? ' primary' : ' warning')}/>
+            <PersonIcon className={'lg' + (Persist.hasCmdrLinks() ? ' primary' : ' warning')}/>
           </div>
         </div>
 
         <div className='r menu'>
           <div className={cn('menu-header')} onClick={this._showHelp}>
-            <Help className='xl warning'/>
+            <Help className='lg warning'/>
           </div>
         </div>
 
         <div className='r menu'>
           <a href="https://github.com/sponsors/Brighter-Applications" target="_blank" rel="noopener noreferrer">
             <div className={cn('menu-header')}>
-              <Heart className='xl warning'/><span className='menu-item-label'>{translate('donate')}</span>
+              <Heart className='lg warning'/><span className='menu-item-label'>{translate('donate')}</span>
             </div>
           </a>
         </div>
 
         <div className='r menu'>
           <div className={cn('menu-header', { selected: openedMenu == 'settings' })} onClick={this._openSettings}>
-            <Cogs className='xl warning'/><span className='menu-item-label'>{translate('settings')}</span>
+            <Cogs className='lg warning'/><span className='menu-item-label'>{translate('settings')}</span>
           </div>
           {openedMenu == 'settings' ? this._getSettingsMenu() : null}
         </div>

--- a/src/app/components/ModalAnnouncements.jsx
+++ b/src/app/components/ModalAnnouncements.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import TranslatedComponent from './TranslatedComponent';
+import cn from 'classnames';
+
+function getVersionPrefix() {
+  const host = window.location.hostname;
+  if (host.includes('alpha')) return 'Alpha v';
+  if (host.includes('beta')) return 'Beta v';
+  return 'v';
+}
+
+/**
+ * Modal showing version announcements with links to changelog
+ */
+export default class ModalAnnouncements extends TranslatedComponent {
+
+  render() {
+    const { announcements } = this.props;
+    const translate = this.context.language.translate;
+    const prefix = getVersionPrefix();
+
+    return (
+      <div className='modal' onClick={(e) => e.stopPropagation()}>
+        <h2>{translate('announcements')}</h2>
+        <div className='announcement-list'>
+          {announcements.slice(0, 7).map((a, i) => (
+            <a key={a.id} href={`/changelog#v${a.version}`} className={cn('announcement-entry', { latest: i === 0 })}>
+              <span className='announcement-version'>{prefix}{a.version}</span>
+              <span className='announcement-text'>{a.text}</span>
+            </a>
+          ))}
+        </div>
+        <button className='r dismiss cap' onClick={this.context.hideModal}>{translate('close')}</button>
+      </div>
+    );
+  }
+}

--- a/src/app/components/SvgIcons.jsx
+++ b/src/app/components/SvgIcons.jsx
@@ -377,6 +377,15 @@ export class Notification extends SvgIcon {
 }
 
 /**
+ * Bell - Notification bell
+ */
+export class Bell extends SvgIcon {
+  svg() {
+    return <path d='M16 0c-1.1 0-2 0.9-2 2v1.3c-4.6 0.9-8 5-8 9.7v6l-4 4v2h28v-2l-4-4v-6c0-4.7-3.4-8.8-8-9.7v-1.3c0-1.1-0.9-2-2-2zM16 32c-2.2 0-4-1.8-4-4h8c0 2.2-1.8 4-4 4z'/>;
+  }
+}
+
+/**
  * Power - Lightning Bolt
  */
 export class Power extends SvgIcon {

--- a/src/app/data/announcements.json
+++ b/src/app/data/announcements.json
@@ -1,5 +1,53 @@
 [
   {
+    "id": 46,
+    "version": "4.0.24",
+    "text": "Builds Button on Firefox fix when no builds saved",
+    "changes": [
+      "Builds Button on Firefox fix when no builds saved"
+    ]
+  },
+  {
+    "id": 45,
+    "version": "4.0.23",
+    "text": "Ensuring the Advanced Planetary Approach Suite is added to imported ships for consistency",
+    "changes": [
+      "Ensuring the Advanced Planetary Approach Suite is added to imported ships for consistency"
+    ]
+  },
+  {
+    "id": 44,
+    "version": "4.0.22",
+    "text": "Auto Select Module Search on Available Modules Menu opening",
+    "changes": [
+      "Auto Select Module Search on Available Modules Menu opening"
+    ]
+  },
+  {
+    "id": 43,
+    "version": "4.0.21",
+    "text": "Fixing layout issue on module selection menu",
+    "changes": [
+      "Fixing layout issue on module selection menu"
+    ]
+  },
+  {
+    "id": 42,
+    "version": "4.0.20",
+    "text": "Made power and costs section collapsible",
+    "changes": [
+      "Made power and costs section collapsible"
+    ]
+  },
+  {
+    "id": 41,
+    "version": "4.0.19",
+    "text": "Fixed Sync Builds option in Settings menu. It now updates the icon to a tick, or cross, when clicked.",
+    "changes": [
+      "Fixed Sync Builds option in Settings menu. It now updates the icon to a tick, or cross, when clicked."
+    ]
+  },
+  {
     "id": 40,
     "version": "4.0.18",
     "text": "Introducing an error boundary to help error reporting",
@@ -80,506 +128,6 @@
     "changes": [
       "Switched to hashed filenames, to reduce caching issues on new releases",
       "Improved release workflow, to be less user intensive and smoother and create releases"
-    ]
-  },
-  {
-    "id": 30,
-    "version": "2.5.1",
-    "text": "Passenger count on main page",
-    "changes": [
-      "Passenger count on main page",
-      "AX Modules",
-      "Engineering fixes",
-      "Use coriolis-data 2.5.1"
-    ]
-  },
-  {
-    "id": 29,
-    "version": "2.5.0",
-    "text": "willyb321 and myself have conquered engineering. Mainly him though...",
-    "changes": [
-      "willyb321 and myself have conquered engineering. Mainly him though...",
-      "Use coriolis-data 2.5.0"
-    ]
-  },
-  {
-    "id": 28,
-    "version": "2.4.2",
-    "text": "Lots of kind people have helped out for this release! Check out the PR history!",
-    "changes": [
-      "Lots of kind people have helped out for this release! Check out the PR history!",
-      "Uses coriolis-data update:",
-      "Fixes issues with repair limpets",
-      "Adds requirement data",
-      "Adds requirements panel",
-      "Adds comma formatting to tooltip numbers"
-    ]
-  },
-  {
-    "id": 27,
-    "version": "2.4.1",
-    "text": "Small patches and changes",
-    "changes": [
-      "Small patches and changes"
-    ]
-  },
-  {
-    "id": 26,
-    "version": "2.4.0",
-    "text": "Changed compression library to Pako",
-    "changes": [
-      "Changed compression library to Pako",
-      "Use coriolis-data 2.4.0",
-      "Repair Limpets added"
-    ]
-  },
-  {
-    "id": 25,
-    "version": "2.3.7",
-    "text": "Fixed Travis test issues",
-    "changes": [
-      "Fixed Travis test issues",
-      "Bumped NodeJS version to provide better compatability and support",
-      "Added updated German Translation",
-      "Fixed issues with Safari",
-      "Use coriolis-data 2.3.7",
-      "Fixed Orca mass-lock"
-    ]
-  },
-  {
-    "id": 24,
-    "version": "2.3.6",
-    "text": "Update miner role to provide better defaults",
-    "changes": [
-      "Update miner role to provide better defaults",
-      "Fix issue where torpedo special effects were not showing",
-      "Fix typo causing long range blueprint to not modify shot speed in some circumstances",
-      "Fix for Spanish translation of Chaff Launcher (thanks to DamonFstr)",
-      "Update for Russian translation (thanks to LeeNTien)",
-      "Use coriolis-data 2.3.6:",
-      "Add shotspeed modifier to cannon/multi-cannon/fragment cannon"
-    ]
-  },
-  {
-    "id": 23,
-    "version": "2.3.5",
-    "text": "Ensure that hidden blueprint effects are applied when a blueprint is selected",
-    "changes": [
-      "Ensure that hidden blueprint effects are applied when a blueprint is selected",
-      "Handle display when summary values show thrusters disabled but current mass keeps them enabled",
-      "Added updated German translations (thanks to @sweisgerber-dev)",
-      "Power state (enabled and priority) now follows modules when they are swapped or copied",
-      "Grey out modules that are powered off to provide a clearer visual indication",
-      "Use coriolis-data 2.3.5:",
-      "Fix list of available blueprints for Point Defence",
-      "Fix integrity values for class 6 power plants",
-      "Add shot speed for long range weapon",
-      "Fix components for dirty drive grade 3",
-      "Update values for Cytoscrambler"
-    ]
-  },
-  {
-    "id": 22,
-    "version": "2.3.4",
-    "text": "Fix crash when removing the special effect from a module",
-    "changes": [
-      "Fix crash when removing the special effect from a module",
-      "Ensure comparisons with saved stock ships work correctly",
-      "Add 'Racer' role",
-      "Tidy up shipyard page; remove units from data columns and re-order for legibility",
-      "Allow basic drag/drop functionality in Edge/Internet Explorer 11 browser",
-      "Provide separate special effects for dumbfire and seeker missiles",
-      "Include special effect modifiers in blueprint tooltip",
-      "Use coriolis-data 2.3.4:",
-      "Add missing Long Range blueprint to multi-cannon",
-      "Fix values for thermal load of focused weapon grade 4",
-      "Fix internal module information for power plant blueprints",
-      "Add 'FSD Interrupt' special to dumbfire missile racks; this module now has `specials_S` and `specials_D` keys for specials to differentiate"
-    ]
-  },
-  {
-    "id": 21,
-    "version": "2.3.3",
-    "text": "Remove unused blueprint when hitting reset",
-    "changes": [
-      "Remove unused blueprint when hitting reset",
-      "Add 'purchase module' external link to EDDB for refit items",
-      "Use coriolis-data 2.3.3:",
-      "Add Felicity Farseer to list of engineers that supply sensor and detailed surface scanner modifications"
-    ]
-  },
-  {
-    "id": 20,
-    "version": "2.3.2",
-    "text": "Use scan range for DSS rather than scan time",
-    "changes": [
-      "Use scan range for DSS rather than scan time",
-      "Fix companion API import of Dolphin",
-      "Use coriolis-data 2.3.2:",
-      "Separate scan time and scan range",
-      "Add Frontier IDs for new items in 2.3",
-      "Update ownership of module blueprints for sensors and scanners",
-      "Update railgun penetration"
-    ]
-  },
-  {
-    "id": 19,
-    "version": "2.3.0",
-    "text": "Make scan time visible on scanners where available",
-    "changes": [
-      "Make scan time visible on scanners where available",
-      "Update power distributor able-to-boost calculation to take fractional MJ values in to account",
-      "Revert to floating header due to issues on iOS",
-      "Fix issue where new module added to a slot did not reset its enabled status",
-      "Show integrity value for relevant modules",
-      "Reset old modification values when a new roll is applied",
-      "Fix issue with miner role where refinery would not be present in ships with class 5 slots but no class 4",
-      "Ensure that boost value is set correctly when modifications to power distributor enable/disable boost",
-      "Ensure that hull reinforcement modifications take the inherent resistance in to account when calculating modification percentages",
-      "Add tooltip for blueprints providing details of the features they alter, the components required for the blueprint and the engineer(s) who cam craft them",
-      "Use opponent's saved pips if available",
-      "Ignore rounds per shot for EPS and HPS calculations; it's already factored in to the numbers",
-      "Ensure that clip size modification imports result in whole numbers",
-      "Rework of separate offence/defence/movement sections to a unified interface",
-      "Use cargo hatch information on import if available",
-      "Additional information of power distributor pips, boost, cargo and fuel loads added to build",
-      "Additional information of opponent and engagement range added to build",
-      "Reworking of offence, defence and movement information in to separate tabs as part of the outfitting screen:",
-      "Power and costs section provides the existing 'Power' and 'Costs' sections",
-      "Profiles section provides a number of graphs that show how various components of the build (top speed, sustained DPS against opponent's shields and armour etc) are affected by mass, range, etc.",
-      "Offence section provides details of your build's damage distribution and per-weapon effectiveness. It also gives summary information for how long it will take for your build to wear down your opponent's shields and armour",
-      "Defence section provides details of your build's defences against your selected opponent. It provides details of the effectiveness of your resistances of both shields and armour, and effective strength of each as a result. It also provides key metrics around shield longevity and recovery times, as well as module protection",
-      "Fix power band marker to show safe power limit at 40% rather than 50%",
-      "Restyle blueprint list to improve consistency with similar menus",
-      "Use coriolis-data 2.3.0:",
-      "Add Dolphin",
-      "Add turreted mining lasers",
-      "Add long range / wide angle / fast scan scanner blueprints",
-      "Fix EDDB IDs for class 5 and 7 fighter hangars for correct shopping list",
-      "Fix cost for rocket-propelled FSD disruptor",
-      "Add module names for blueprints",
-      "Fix erroneous value for grade 5 kinetic shield booster",
-      "Add missing integrity values for some modules",
-      "Update module reinforcement package integrity",
-      "Update specs of Beluga as per 2.3",
-      "Update specs of Asp Scout as per 2.3",
-      "Update specs of Diamondback Explorer as per 2.3",
-      "Add ED ID for Rocket Propelled FSD Disruptor",
-      "Fix ED name for target lock breaker special",
-      "Update scan range and angle information for sensors",
-      "Tidy up shield cell bank information to allow for accurate calculations with modifications",
-      "Update mine launcher stats",
-      "Add appropriate engineers to per-module blueprint information"
-    ]
-  },
-  {
-    "id": 18,
-    "version": "2.2.19",
-    "text": "Power management panel now displays modules in descending order of power usage by default",
-    "changes": [
-      "Power management panel now displays modules in descending order of power usage by default",
-      "Shot speed can no longer be modified directly.  Its value is derived from the range modifier for Long Range and Focused modifications",
-      "Ensure that jump range chart updates when fuel slider is changed",
-      "Add 'Engine profile' and 'FSD profile' charts.  These show how your maximum speed/jump range will alter as you alter the mass of your build",
-      "Use coriolis-data 2.2.19:",
-      "Remove shot speed modification - it is directly tied to range",
-      "Fix incorrect minimal mass for 3C bi-weave shield generator"
-    ]
-  },
-  {
-    "id": 17,
-    "version": "2.2.18",
-    "text": "Change methodology for calculating explorer role; can result in lighter builds",
-    "changes": [
-      "Change methodology for calculating explorer role; can result in lighter builds",
-      "Tidy up layout for module selection and lay everything out in a consistent best-to-worst for both class and grade",
-      "Make integrity for module reinforcement packages visible",
-      "Clean up breakpoints for modules in available modules list; stops 7- or 8- module long lines",
-      "Add damager/range graphs to damage dealt",
-      "Reorder panels",
-      "Use coriolis-data 2.2.18:",
-      "Correct lower efficiency value to be better, not worse"
-    ]
-  },
-  {
-    "id": 16,
-    "version": "2.2.17",
-    "text": "Use in-game terminology for shield generator optmul and optmass items",
-    "changes": [
-      "Use in-game terminology for shield generator optmul and optmass items",
-      "Add crew to shipyard and outfitting page information",
-      "Use coriolis-data 2.2.17:",
-      "Add mass as potential SCB modification",
-      "Fix mining laser statistics",
-      "Remove non-existent grade 4 and 5 wake scanner modifications",
-      "Add number of crew for each ship"
-    ]
-  },
-  {
-    "id": 15,
-    "version": "2.2.16",
-    "text": "Fix 'Extreme' blueprint roll where some incorrect ranges were chosen",
-    "changes": [
-      "Fix 'Extreme' blueprint roll where some incorrect ranges were chosen",
-      "Use coriolis-data 2.2.16:",
-      "Fix incorrect thermal load modifiers for dirty drives",
-      "Provide explicit information about if values are higher numeric value == better or not"
-    ]
-  },
-  {
-    "id": 14,
-    "version": "2.2.15",
-    "text": "Ensure that standard slots are repainted when any component changes",
-    "changes": [
-      "Ensure that standard slots are repainted when any component changes",
-      "Reload page if Safari throws a security error",
-      "Handle import of ships with incorrectly-sized slots",
-      "Add 'Extreme' blueprint roll: best beneficial and worst detrimental outcome (in place of 'Average' roll)",
-      "Display information about Microsoft browser issues when an import fails",
-      "Add 'purchase this build' icon link to EDDB",
-      "Add 'miner' and 'shielded miner' ship roles",
-      "Use coriolis-data 2.2.15:",
-      "Fix location of initial cargo rack for Vulture",
-      "Fix broken regeneration rate for 6B shield generators",
-      "Tidy up breach damage values"
-    ]
-  },
-  {
-    "id": 13,
-    "version": "2.2.14",
-    "text": "Ensure that jitter is shown correctly when the result of a special effect",
-    "changes": [
-      "Ensure that jitter is shown correctly when the result of a special effect",
-      "Use restyled blueprint information",
-      "Use the ship name (if available) rather than the ship model for the window title",
-      "Use coriolis-data 2.2.14:",
-      "Alter blueprint structure to combine components and features",
-      "Make hidden value of modifications its own attribute",
-      "Fix incorrect ED ID for class 6 passenger cabins"
-    ]
-  },
-  {
-    "id": 12,
-    "version": "2.2.13",
-    "text": "Add 'time to drain' summary value.  This is the time to drain the WEP capacitor if firing all enabled weapons",
-    "changes": [
-      "Add 'time to drain' summary value.  This is the time to drain the WEP capacitor if firing all enabled weapons",
-      "Do not include utility slot DPS/EPS/HPS in summary information",
-      "Ensure that auto loader special shows in the tooltip",
-      "Ensure that ship mass is recalculated when appropriate",
-      "Use coriolis-data 2.2.13:",
-      "Add plasma slug special effect for plasma accelerator",
-      "Tweak hull costs of ships"
-    ]
-  },
-  {
-    "id": 11,
-    "version": "2.2.12",
-    "text": "Tidy up old references to coriolis.io",
-    "changes": [
-      "Tidy up old references to coriolis.io",
-      "Add ability to add and remove special effects to weapon modifications",
-      "Add weapon engineering information to Damage Dealt section",
-      "Change shortcut for link from ctrl-l to ctrl-o to avoid clash with location bar",
-      "Only show one of power generation or draw in tooltips, according to module",
-      "Use coriolis-data 2.2.12:",
-      "Add special effects for each blueprint",
-      "Add IDs for most Powerplay modules"
-    ]
-  },
-  {
-    "id": 10,
-    "version": "2.2.11",
-    "text": "Add help system and initial help file",
-    "changes": [
-      "Add help system and initial help file",
-      "Make absolute damage visible",
-      "Add 'average' roll for blueprints",
-      "Update spacing for movement summary to make it more readable",
-      "Provide damage dealt statistics for both shields and hull",
-      "Damage dealt panel only shows enabled weapons",
-      "Add engagement range to damage received panel",
-      "Handle burst rate of fire as an absolute number rather than a perentage modification",
-      "Ensure that clip values are always rounded up",
-      "Ensure that focused weapon mod uses range modifier to increase falloff as well",
-      "Use coriolis-data 2.2.11:",
-      "Remove non-existent chaff launcher capacity blueprint grades",
-      "Fix incorrect values for charge enhanced power distributor",
-      "Remove incorrect AFMU blueprints",
-      "Correct fragment cannon Double Shot blueprint information",
-      "Correct Focused weapon blueprint information"
-    ]
-  },
-  {
-    "id": 9,
-    "version": "2.2.10",
-    "text": "Fix detailed export of module reinforcement packages",
-    "changes": [
-      "Fix detailed export of module reinforcement packages",
-      "Use damagedist for exact breakdown of weapons that have more than one type of damage",
-      "Use new-style modification validity data",
-      "Provide ability to select engineering blueprint and roll sample values for them",
-      "Use coriolis-data 2.2.10:",
-      "Fix incorrect base shield values for Cutter and Corvette",
-      "Update weapons to have %-based damage distributions",
-      "Remove power draw for detailed surface scanner - although shown in outfitting it is not part of active power",
-      "Fix incorrect names for lightweight and kinetic armour",
-      "Add engineering blueprints"
-    ]
-  },
-  {
-    "id": 8,
-    "version": "2.2.9",
-    "text": "Use SSL-enabled server for shortlinks",
-    "changes": [
-      "Use SSL-enabled server for shortlinks",
-      "Add falloff for weapons",
-      "Use falloff when calculating weapon effectiveness in damage dealt",
-      "Add engagement range slider to 'Damage Dealt' section to allow user to see change in weapon effectiveness with range",
-      "Use better DPE calculation methodology",
-      "Add total DPS and effectiveness information to 'Damage Dealt' section",
-      "Use coriolis-data 2.2.9:",
-      "Add falloff metric for weapons",
-      "Add falloff from range modification"
-    ]
-  },
-  {
-    "id": 7,
-    "version": "2.2.8",
-    "text": "Fix issue where filling all internals with cargo racks would include restricted slots",
-    "changes": [
-      "Fix issue where filling all internals with cargo racks would include restricted slots",
-      "Use coriolis-data 2.2.8:",
-      "Set military slot of Viper Mk IV to class 3; was incorrectly set as class 2",
-      "Update base regeneration rate of prismatic shield generators to values in 2.2.03",
-      "Update specials with information in 2.2.03"
-    ]
-  },
-  {
-    "id": 6,
-    "version": "2.2.7",
-    "text": "Fix resistance diminishing return calculations",
-    "changes": [
-      "Fix resistance diminishing return calculations",
-      "Do not allow -100% to be entered as a modification value"
-    ]
-  },
-  {
-    "id": 5,
-    "version": "2.2.6",
-    "text": "Add pitch/roll/yaw information",
-    "changes": [
-      "Add pitch/roll/yaw information",
-      "Use combination of pitch, roll and yaw to provide a more useful agility metric",
-      "Add movement summary to outfitting page",
-      "Add standard internal class sizes to shipyard page",
-      "Fix issue when importing Viper Mk IV",
-      "Ensure ordering of all types of modules (standard, internal, utilities) is consistent",
-      "Add rebuilds per bay information for fighter hangars",
-      "Add ability to show military compartments",
-      "Show module reinforcement package results in defence summary",
-      "Use separate speed/rotation/acceleration multipliers for thrusters if available",
-      "Obey restricted slot rules when adding all for internal slots",
-      "Version URLs to handle changes to ship specifications over time",
-      "Do not include disabled shield boosters in calculations",
-      "Add 'Damage dealt' section",
-      "Add 'Damage received' section",
-      "Add 'Piercing' information to hardpoints",
-      "Add 'Hardness' information to ship summary",
-      "Add module copy functionality - drag module whilst holding 'alt' to copy",
-      "Add base resistances to defence summary tooltip",
-      "Update shield recovery/regeneration calculations",
-      "Pin menu to top of page",
-      "Switch to custom shortlink method to avoid google length limitations",
-      "Ensure that information is not lost on narrow screens",
-      "Do not lose ship selector selection on narrow screens",
-      "Reinstate jump range graph",
-      "Use coriolis-data 2.2.6:",
-      "Update weapons with changed values for 2.2.03",
-      "Add individual pitch/roll/yaw statistics for each ship",
-      "Remove old and meaningless agility stat",
-      "Use sane order for multi-module JSON - coriolis can re-order as it sees fit when displaying modules",
-      "Fix cost of fighter hangars",
-      "Update Powerplay weapons with current statistics",
-      "Add separate min/opt/max multipliers for enhanced thrusters for speed, acceleration and rotation",
-      "Add module reinforcement packages",
-      "Add military compartments",
-      "Fix missing damage value for 2B dumbfires",
-      "Update shield recharge rates",
-      "Reduce hull mass of Viper to 50T",
-      "Fix incorrect optimal mass value for 8A thrusters",
-      "Add power draw for detailed surface scanner"
-    ]
-  },
-  {
-    "id": 4,
-    "version": "2.2.5",
-    "text": "Calculate rate of fire for multi-burst weapons",
-    "changes": [
-      "Calculate rate of fire for multi-burst weapons",
-      "Add note to disable ghostery in error situation",
-      "Use coriolis-data 2.2.5:",
-      "Fix incorrect ID for emissive munitions special",
-      "Fix rate of fire for burst lasers",
-      "Add fragment cannon modifications",
-      "Fix internal name of dazzle shell"
-    ]
-  },
-  {
-    "id": 3,
-    "version": "2.2.4",
-    "text": "Add shortlink for outfitting page",
-    "changes": [
-      "Add shortlink for outfitting page",
-      "Use coriolis-data 2.2.4:",
-      "Fix incorrect ID for class 5 luxury passenger cabin",
-      "Add damage type modifier",
-      "Change modifications from simple strings to objects, to allow more data-driven behaviour",
-      "Add special effects",
-      "Modification tooltip now shows special effect"
-    ]
-  },
-  {
-    "id": 2,
-    "version": "2.2.3",
-    "text": "Fix hull boost calculation - now shows correct % modifier and total armour",
-    "changes": [
-      "Fix hull boost calculation - now shows correct % modifier and total armour",
-      "Fix import of DiamondBack - can now be imported",
-      "Fix import of Beluga - can now be imported",
-      "Use coriolis-data 2.2.3:",
-      "Fix mismatch between class 5 and class 7 fighter hangars - now shows correct module",
-      "Add details for concordant sequence special effect - now shows correct damage",
-      "Fix details for thermal shock special effect - now shows correct damage",
-      "Add engineer blueprints",
-      "Modification tooltip now shows name and grade of modifications for imported builds",
-      "Retain import URL unless user changes the build - allows future updates of Coriolis to take advantage of additional build information"
-    ]
-  },
-  {
-    "id": 1,
-    "version": "2.2.2",
-    "text": "Update DPS/HPS/EPS in real-time as modifiers change",
-    "changes": [
-      "Update DPS/HPS/EPS in real-time as modifiers change",
-      "Use coriolis-data 2.2.2:",
-      "Add distributor draw modifier to shield generators",
-      "Remove modifiers for sensors",
-      "Add initial loadout passenger cabins for Beluga",
-      "Add initial loadout passenger cabins for Orca",
-      "Update costs and initial loadouts for Keelback and Type-7",
-      "Add resistances for hull reinforcement packages",
-      "Added modifier actions to create modifications from raw data",
-      "Show modification icon for modified modules",
-      "Take modifications in to account when deciding whether to issue a warning on a standard module",
-      "Fix hardpoint comparison DPS number when selecting an alternate module",
-      "Ensure that retrofit tab only shows changed modules",
-      "Fix import and export of ships with modifications, bump schema version to 4",
-      "Enable boost display even if power distributor is disabled",
-      "Calculate breakdown of ship offensive and defensive stats",
-      "Add 'Offence summary' and 'Defence summary' components",
-      "Add ability to import from companion API output through import feature",
-      "Add ability to import from companion API output through URL"
     ]
   }
 ]

--- a/src/app/data/announcements.json
+++ b/src/app/data/announcements.json
@@ -1,0 +1,585 @@
+[
+  {
+    "id": 40,
+    "version": "4.0.18",
+    "text": "Introducing an error boundary to help error reporting",
+    "changes": [
+      "Introducing an error boundary to help error reporting"
+    ]
+  },
+  {
+    "id": 39,
+    "version": "4.0.17",
+    "text": "CMDR-Coriolis started accepting MaterialTrade events from the journal",
+    "changes": [
+      "CMDR-Coriolis started accepting MaterialTrade events from the journal"
+    ]
+  },
+  {
+    "id": 38,
+    "version": "4.0.16",
+    "text": "CMDR-Coriolis started accepting MaterialCollected events from the journal",
+    "changes": [
+      "CMDR-Coriolis started accepting MaterialCollected events from the journal"
+    ]
+  },
+  {
+    "id": 37,
+    "version": "4.0.15",
+    "text": "Adding to documentation for CMDR-Coriolis new Journal API",
+    "changes": [
+      "Adding to documentation for CMDR-Coriolis new Journal API",
+      "Georgian Translation update"
+    ]
+  },
+  {
+    "id": 36,
+    "version": "4.0.14",
+    "text": "Fixed JSON/SLEF Exports to include proper engineering and FSD Ranges",
+    "changes": [
+      "Fixed JSON/SLEF Exports to include proper engineering and FSD Ranges"
+    ]
+  },
+  {
+    "id": 35,
+    "version": "4.0.13",
+    "text": "Fixed fuelmul on V1 SCO Drive",
+    "changes": [
+      "Fixed fuelmul on V1 SCO Drive",
+      "Fixing double engineered module calculations"
+    ]
+  },
+  {
+    "id": 34,
+    "version": "4.0.12",
+    "text": "Resolved issue with Builds Menu throwing an error when the user has no builds.",
+    "changes": [
+      "Resolved issue with Builds Menu throwing an error when the user has no builds."
+    ]
+  },
+  {
+    "id": 33,
+    "version": "4.0.11",
+    "text": "Fixed highliner tonnage, it was 250 and should have been 260",
+    "changes": [
+      "Fixed highliner tonnage, it was 250 and should have been 260"
+    ]
+  },
+  {
+    "id": 32,
+    "version": "4.0.10",
+    "text": "Fixed slot indexing for Lynx Highliner",
+    "changes": [
+      "Fixed slot indexing for Lynx Highliner"
+    ]
+  },
+  {
+    "id": 31,
+    "version": "4.0.9",
+    "text": "Switched to hashed filenames, to reduce caching issues on new releases",
+    "changes": [
+      "Switched to hashed filenames, to reduce caching issues on new releases",
+      "Improved release workflow, to be less user intensive and smoother and create releases"
+    ]
+  },
+  {
+    "id": 30,
+    "version": "2.5.1",
+    "text": "Passenger count on main page",
+    "changes": [
+      "Passenger count on main page",
+      "AX Modules",
+      "Engineering fixes",
+      "Use coriolis-data 2.5.1"
+    ]
+  },
+  {
+    "id": 29,
+    "version": "2.5.0",
+    "text": "willyb321 and myself have conquered engineering. Mainly him though...",
+    "changes": [
+      "willyb321 and myself have conquered engineering. Mainly him though...",
+      "Use coriolis-data 2.5.0"
+    ]
+  },
+  {
+    "id": 28,
+    "version": "2.4.2",
+    "text": "Lots of kind people have helped out for this release! Check out the PR history!",
+    "changes": [
+      "Lots of kind people have helped out for this release! Check out the PR history!",
+      "Uses coriolis-data update:",
+      "Fixes issues with repair limpets",
+      "Adds requirement data",
+      "Adds requirements panel",
+      "Adds comma formatting to tooltip numbers"
+    ]
+  },
+  {
+    "id": 27,
+    "version": "2.4.1",
+    "text": "Small patches and changes",
+    "changes": [
+      "Small patches and changes"
+    ]
+  },
+  {
+    "id": 26,
+    "version": "2.4.0",
+    "text": "Changed compression library to Pako",
+    "changes": [
+      "Changed compression library to Pako",
+      "Use coriolis-data 2.4.0",
+      "Repair Limpets added"
+    ]
+  },
+  {
+    "id": 25,
+    "version": "2.3.7",
+    "text": "Fixed Travis test issues",
+    "changes": [
+      "Fixed Travis test issues",
+      "Bumped NodeJS version to provide better compatability and support",
+      "Added updated German Translation",
+      "Fixed issues with Safari",
+      "Use coriolis-data 2.3.7",
+      "Fixed Orca mass-lock"
+    ]
+  },
+  {
+    "id": 24,
+    "version": "2.3.6",
+    "text": "Update miner role to provide better defaults",
+    "changes": [
+      "Update miner role to provide better defaults",
+      "Fix issue where torpedo special effects were not showing",
+      "Fix typo causing long range blueprint to not modify shot speed in some circumstances",
+      "Fix for Spanish translation of Chaff Launcher (thanks to DamonFstr)",
+      "Update for Russian translation (thanks to LeeNTien)",
+      "Use coriolis-data 2.3.6:",
+      "Add shotspeed modifier to cannon/multi-cannon/fragment cannon"
+    ]
+  },
+  {
+    "id": 23,
+    "version": "2.3.5",
+    "text": "Ensure that hidden blueprint effects are applied when a blueprint is selected",
+    "changes": [
+      "Ensure that hidden blueprint effects are applied when a blueprint is selected",
+      "Handle display when summary values show thrusters disabled but current mass keeps them enabled",
+      "Added updated German translations (thanks to @sweisgerber-dev)",
+      "Power state (enabled and priority) now follows modules when they are swapped or copied",
+      "Grey out modules that are powered off to provide a clearer visual indication",
+      "Use coriolis-data 2.3.5:",
+      "Fix list of available blueprints for Point Defence",
+      "Fix integrity values for class 6 power plants",
+      "Add shot speed for long range weapon",
+      "Fix components for dirty drive grade 3",
+      "Update values for Cytoscrambler"
+    ]
+  },
+  {
+    "id": 22,
+    "version": "2.3.4",
+    "text": "Fix crash when removing the special effect from a module",
+    "changes": [
+      "Fix crash when removing the special effect from a module",
+      "Ensure comparisons with saved stock ships work correctly",
+      "Add 'Racer' role",
+      "Tidy up shipyard page; remove units from data columns and re-order for legibility",
+      "Allow basic drag/drop functionality in Edge/Internet Explorer 11 browser",
+      "Provide separate special effects for dumbfire and seeker missiles",
+      "Include special effect modifiers in blueprint tooltip",
+      "Use coriolis-data 2.3.4:",
+      "Add missing Long Range blueprint to multi-cannon",
+      "Fix values for thermal load of focused weapon grade 4",
+      "Fix internal module information for power plant blueprints",
+      "Add 'FSD Interrupt' special to dumbfire missile racks; this module now has `specials_S` and `specials_D` keys for specials to differentiate"
+    ]
+  },
+  {
+    "id": 21,
+    "version": "2.3.3",
+    "text": "Remove unused blueprint when hitting reset",
+    "changes": [
+      "Remove unused blueprint when hitting reset",
+      "Add 'purchase module' external link to EDDB for refit items",
+      "Use coriolis-data 2.3.3:",
+      "Add Felicity Farseer to list of engineers that supply sensor and detailed surface scanner modifications"
+    ]
+  },
+  {
+    "id": 20,
+    "version": "2.3.2",
+    "text": "Use scan range for DSS rather than scan time",
+    "changes": [
+      "Use scan range for DSS rather than scan time",
+      "Fix companion API import of Dolphin",
+      "Use coriolis-data 2.3.2:",
+      "Separate scan time and scan range",
+      "Add Frontier IDs for new items in 2.3",
+      "Update ownership of module blueprints for sensors and scanners",
+      "Update railgun penetration"
+    ]
+  },
+  {
+    "id": 19,
+    "version": "2.3.0",
+    "text": "Make scan time visible on scanners where available",
+    "changes": [
+      "Make scan time visible on scanners where available",
+      "Update power distributor able-to-boost calculation to take fractional MJ values in to account",
+      "Revert to floating header due to issues on iOS",
+      "Fix issue where new module added to a slot did not reset its enabled status",
+      "Show integrity value for relevant modules",
+      "Reset old modification values when a new roll is applied",
+      "Fix issue with miner role where refinery would not be present in ships with class 5 slots but no class 4",
+      "Ensure that boost value is set correctly when modifications to power distributor enable/disable boost",
+      "Ensure that hull reinforcement modifications take the inherent resistance in to account when calculating modification percentages",
+      "Add tooltip for blueprints providing details of the features they alter, the components required for the blueprint and the engineer(s) who cam craft them",
+      "Use opponent's saved pips if available",
+      "Ignore rounds per shot for EPS and HPS calculations; it's already factored in to the numbers",
+      "Ensure that clip size modification imports result in whole numbers",
+      "Rework of separate offence/defence/movement sections to a unified interface",
+      "Use cargo hatch information on import if available",
+      "Additional information of power distributor pips, boost, cargo and fuel loads added to build",
+      "Additional information of opponent and engagement range added to build",
+      "Reworking of offence, defence and movement information in to separate tabs as part of the outfitting screen:",
+      "Power and costs section provides the existing 'Power' and 'Costs' sections",
+      "Profiles section provides a number of graphs that show how various components of the build (top speed, sustained DPS against opponent's shields and armour etc) are affected by mass, range, etc.",
+      "Offence section provides details of your build's damage distribution and per-weapon effectiveness. It also gives summary information for how long it will take for your build to wear down your opponent's shields and armour",
+      "Defence section provides details of your build's defences against your selected opponent. It provides details of the effectiveness of your resistances of both shields and armour, and effective strength of each as a result. It also provides key metrics around shield longevity and recovery times, as well as module protection",
+      "Fix power band marker to show safe power limit at 40% rather than 50%",
+      "Restyle blueprint list to improve consistency with similar menus",
+      "Use coriolis-data 2.3.0:",
+      "Add Dolphin",
+      "Add turreted mining lasers",
+      "Add long range / wide angle / fast scan scanner blueprints",
+      "Fix EDDB IDs for class 5 and 7 fighter hangars for correct shopping list",
+      "Fix cost for rocket-propelled FSD disruptor",
+      "Add module names for blueprints",
+      "Fix erroneous value for grade 5 kinetic shield booster",
+      "Add missing integrity values for some modules",
+      "Update module reinforcement package integrity",
+      "Update specs of Beluga as per 2.3",
+      "Update specs of Asp Scout as per 2.3",
+      "Update specs of Diamondback Explorer as per 2.3",
+      "Add ED ID for Rocket Propelled FSD Disruptor",
+      "Fix ED name for target lock breaker special",
+      "Update scan range and angle information for sensors",
+      "Tidy up shield cell bank information to allow for accurate calculations with modifications",
+      "Update mine launcher stats",
+      "Add appropriate engineers to per-module blueprint information"
+    ]
+  },
+  {
+    "id": 18,
+    "version": "2.2.19",
+    "text": "Power management panel now displays modules in descending order of power usage by default",
+    "changes": [
+      "Power management panel now displays modules in descending order of power usage by default",
+      "Shot speed can no longer be modified directly.  Its value is derived from the range modifier for Long Range and Focused modifications",
+      "Ensure that jump range chart updates when fuel slider is changed",
+      "Add 'Engine profile' and 'FSD profile' charts.  These show how your maximum speed/jump range will alter as you alter the mass of your build",
+      "Use coriolis-data 2.2.19:",
+      "Remove shot speed modification - it is directly tied to range",
+      "Fix incorrect minimal mass for 3C bi-weave shield generator"
+    ]
+  },
+  {
+    "id": 17,
+    "version": "2.2.18",
+    "text": "Change methodology for calculating explorer role; can result in lighter builds",
+    "changes": [
+      "Change methodology for calculating explorer role; can result in lighter builds",
+      "Tidy up layout for module selection and lay everything out in a consistent best-to-worst for both class and grade",
+      "Make integrity for module reinforcement packages visible",
+      "Clean up breakpoints for modules in available modules list; stops 7- or 8- module long lines",
+      "Add damager/range graphs to damage dealt",
+      "Reorder panels",
+      "Use coriolis-data 2.2.18:",
+      "Correct lower efficiency value to be better, not worse"
+    ]
+  },
+  {
+    "id": 16,
+    "version": "2.2.17",
+    "text": "Use in-game terminology for shield generator optmul and optmass items",
+    "changes": [
+      "Use in-game terminology for shield generator optmul and optmass items",
+      "Add crew to shipyard and outfitting page information",
+      "Use coriolis-data 2.2.17:",
+      "Add mass as potential SCB modification",
+      "Fix mining laser statistics",
+      "Remove non-existent grade 4 and 5 wake scanner modifications",
+      "Add number of crew for each ship"
+    ]
+  },
+  {
+    "id": 15,
+    "version": "2.2.16",
+    "text": "Fix 'Extreme' blueprint roll where some incorrect ranges were chosen",
+    "changes": [
+      "Fix 'Extreme' blueprint roll where some incorrect ranges were chosen",
+      "Use coriolis-data 2.2.16:",
+      "Fix incorrect thermal load modifiers for dirty drives",
+      "Provide explicit information about if values are higher numeric value == better or not"
+    ]
+  },
+  {
+    "id": 14,
+    "version": "2.2.15",
+    "text": "Ensure that standard slots are repainted when any component changes",
+    "changes": [
+      "Ensure that standard slots are repainted when any component changes",
+      "Reload page if Safari throws a security error",
+      "Handle import of ships with incorrectly-sized slots",
+      "Add 'Extreme' blueprint roll: best beneficial and worst detrimental outcome (in place of 'Average' roll)",
+      "Display information about Microsoft browser issues when an import fails",
+      "Add 'purchase this build' icon link to EDDB",
+      "Add 'miner' and 'shielded miner' ship roles",
+      "Use coriolis-data 2.2.15:",
+      "Fix location of initial cargo rack for Vulture",
+      "Fix broken regeneration rate for 6B shield generators",
+      "Tidy up breach damage values"
+    ]
+  },
+  {
+    "id": 13,
+    "version": "2.2.14",
+    "text": "Ensure that jitter is shown correctly when the result of a special effect",
+    "changes": [
+      "Ensure that jitter is shown correctly when the result of a special effect",
+      "Use restyled blueprint information",
+      "Use the ship name (if available) rather than the ship model for the window title",
+      "Use coriolis-data 2.2.14:",
+      "Alter blueprint structure to combine components and features",
+      "Make hidden value of modifications its own attribute",
+      "Fix incorrect ED ID for class 6 passenger cabins"
+    ]
+  },
+  {
+    "id": 12,
+    "version": "2.2.13",
+    "text": "Add 'time to drain' summary value.  This is the time to drain the WEP capacitor if firing all enabled weapons",
+    "changes": [
+      "Add 'time to drain' summary value.  This is the time to drain the WEP capacitor if firing all enabled weapons",
+      "Do not include utility slot DPS/EPS/HPS in summary information",
+      "Ensure that auto loader special shows in the tooltip",
+      "Ensure that ship mass is recalculated when appropriate",
+      "Use coriolis-data 2.2.13:",
+      "Add plasma slug special effect for plasma accelerator",
+      "Tweak hull costs of ships"
+    ]
+  },
+  {
+    "id": 11,
+    "version": "2.2.12",
+    "text": "Tidy up old references to coriolis.io",
+    "changes": [
+      "Tidy up old references to coriolis.io",
+      "Add ability to add and remove special effects to weapon modifications",
+      "Add weapon engineering information to Damage Dealt section",
+      "Change shortcut for link from ctrl-l to ctrl-o to avoid clash with location bar",
+      "Only show one of power generation or draw in tooltips, according to module",
+      "Use coriolis-data 2.2.12:",
+      "Add special effects for each blueprint",
+      "Add IDs for most Powerplay modules"
+    ]
+  },
+  {
+    "id": 10,
+    "version": "2.2.11",
+    "text": "Add help system and initial help file",
+    "changes": [
+      "Add help system and initial help file",
+      "Make absolute damage visible",
+      "Add 'average' roll for blueprints",
+      "Update spacing for movement summary to make it more readable",
+      "Provide damage dealt statistics for both shields and hull",
+      "Damage dealt panel only shows enabled weapons",
+      "Add engagement range to damage received panel",
+      "Handle burst rate of fire as an absolute number rather than a perentage modification",
+      "Ensure that clip values are always rounded up",
+      "Ensure that focused weapon mod uses range modifier to increase falloff as well",
+      "Use coriolis-data 2.2.11:",
+      "Remove non-existent chaff launcher capacity blueprint grades",
+      "Fix incorrect values for charge enhanced power distributor",
+      "Remove incorrect AFMU blueprints",
+      "Correct fragment cannon Double Shot blueprint information",
+      "Correct Focused weapon blueprint information"
+    ]
+  },
+  {
+    "id": 9,
+    "version": "2.2.10",
+    "text": "Fix detailed export of module reinforcement packages",
+    "changes": [
+      "Fix detailed export of module reinforcement packages",
+      "Use damagedist for exact breakdown of weapons that have more than one type of damage",
+      "Use new-style modification validity data",
+      "Provide ability to select engineering blueprint and roll sample values for them",
+      "Use coriolis-data 2.2.10:",
+      "Fix incorrect base shield values for Cutter and Corvette",
+      "Update weapons to have %-based damage distributions",
+      "Remove power draw for detailed surface scanner - although shown in outfitting it is not part of active power",
+      "Fix incorrect names for lightweight and kinetic armour",
+      "Add engineering blueprints"
+    ]
+  },
+  {
+    "id": 8,
+    "version": "2.2.9",
+    "text": "Use SSL-enabled server for shortlinks",
+    "changes": [
+      "Use SSL-enabled server for shortlinks",
+      "Add falloff for weapons",
+      "Use falloff when calculating weapon effectiveness in damage dealt",
+      "Add engagement range slider to 'Damage Dealt' section to allow user to see change in weapon effectiveness with range",
+      "Use better DPE calculation methodology",
+      "Add total DPS and effectiveness information to 'Damage Dealt' section",
+      "Use coriolis-data 2.2.9:",
+      "Add falloff metric for weapons",
+      "Add falloff from range modification"
+    ]
+  },
+  {
+    "id": 7,
+    "version": "2.2.8",
+    "text": "Fix issue where filling all internals with cargo racks would include restricted slots",
+    "changes": [
+      "Fix issue where filling all internals with cargo racks would include restricted slots",
+      "Use coriolis-data 2.2.8:",
+      "Set military slot of Viper Mk IV to class 3; was incorrectly set as class 2",
+      "Update base regeneration rate of prismatic shield generators to values in 2.2.03",
+      "Update specials with information in 2.2.03"
+    ]
+  },
+  {
+    "id": 6,
+    "version": "2.2.7",
+    "text": "Fix resistance diminishing return calculations",
+    "changes": [
+      "Fix resistance diminishing return calculations",
+      "Do not allow -100% to be entered as a modification value"
+    ]
+  },
+  {
+    "id": 5,
+    "version": "2.2.6",
+    "text": "Add pitch/roll/yaw information",
+    "changes": [
+      "Add pitch/roll/yaw information",
+      "Use combination of pitch, roll and yaw to provide a more useful agility metric",
+      "Add movement summary to outfitting page",
+      "Add standard internal class sizes to shipyard page",
+      "Fix issue when importing Viper Mk IV",
+      "Ensure ordering of all types of modules (standard, internal, utilities) is consistent",
+      "Add rebuilds per bay information for fighter hangars",
+      "Add ability to show military compartments",
+      "Show module reinforcement package results in defence summary",
+      "Use separate speed/rotation/acceleration multipliers for thrusters if available",
+      "Obey restricted slot rules when adding all for internal slots",
+      "Version URLs to handle changes to ship specifications over time",
+      "Do not include disabled shield boosters in calculations",
+      "Add 'Damage dealt' section",
+      "Add 'Damage received' section",
+      "Add 'Piercing' information to hardpoints",
+      "Add 'Hardness' information to ship summary",
+      "Add module copy functionality - drag module whilst holding 'alt' to copy",
+      "Add base resistances to defence summary tooltip",
+      "Update shield recovery/regeneration calculations",
+      "Pin menu to top of page",
+      "Switch to custom shortlink method to avoid google length limitations",
+      "Ensure that information is not lost on narrow screens",
+      "Do not lose ship selector selection on narrow screens",
+      "Reinstate jump range graph",
+      "Use coriolis-data 2.2.6:",
+      "Update weapons with changed values for 2.2.03",
+      "Add individual pitch/roll/yaw statistics for each ship",
+      "Remove old and meaningless agility stat",
+      "Use sane order for multi-module JSON - coriolis can re-order as it sees fit when displaying modules",
+      "Fix cost of fighter hangars",
+      "Update Powerplay weapons with current statistics",
+      "Add separate min/opt/max multipliers for enhanced thrusters for speed, acceleration and rotation",
+      "Add module reinforcement packages",
+      "Add military compartments",
+      "Fix missing damage value for 2B dumbfires",
+      "Update shield recharge rates",
+      "Reduce hull mass of Viper to 50T",
+      "Fix incorrect optimal mass value for 8A thrusters",
+      "Add power draw for detailed surface scanner"
+    ]
+  },
+  {
+    "id": 4,
+    "version": "2.2.5",
+    "text": "Calculate rate of fire for multi-burst weapons",
+    "changes": [
+      "Calculate rate of fire for multi-burst weapons",
+      "Add note to disable ghostery in error situation",
+      "Use coriolis-data 2.2.5:",
+      "Fix incorrect ID for emissive munitions special",
+      "Fix rate of fire for burst lasers",
+      "Add fragment cannon modifications",
+      "Fix internal name of dazzle shell"
+    ]
+  },
+  {
+    "id": 3,
+    "version": "2.2.4",
+    "text": "Add shortlink for outfitting page",
+    "changes": [
+      "Add shortlink for outfitting page",
+      "Use coriolis-data 2.2.4:",
+      "Fix incorrect ID for class 5 luxury passenger cabin",
+      "Add damage type modifier",
+      "Change modifications from simple strings to objects, to allow more data-driven behaviour",
+      "Add special effects",
+      "Modification tooltip now shows special effect"
+    ]
+  },
+  {
+    "id": 2,
+    "version": "2.2.3",
+    "text": "Fix hull boost calculation - now shows correct % modifier and total armour",
+    "changes": [
+      "Fix hull boost calculation - now shows correct % modifier and total armour",
+      "Fix import of DiamondBack - can now be imported",
+      "Fix import of Beluga - can now be imported",
+      "Use coriolis-data 2.2.3:",
+      "Fix mismatch between class 5 and class 7 fighter hangars - now shows correct module",
+      "Add details for concordant sequence special effect - now shows correct damage",
+      "Fix details for thermal shock special effect - now shows correct damage",
+      "Add engineer blueprints",
+      "Modification tooltip now shows name and grade of modifications for imported builds",
+      "Retain import URL unless user changes the build - allows future updates of Coriolis to take advantage of additional build information"
+    ]
+  },
+  {
+    "id": 1,
+    "version": "2.2.2",
+    "text": "Update DPS/HPS/EPS in real-time as modifiers change",
+    "changes": [
+      "Update DPS/HPS/EPS in real-time as modifiers change",
+      "Use coriolis-data 2.2.2:",
+      "Add distributor draw modifier to shield generators",
+      "Remove modifiers for sensors",
+      "Add initial loadout passenger cabins for Beluga",
+      "Add initial loadout passenger cabins for Orca",
+      "Update costs and initial loadouts for Keelback and Type-7",
+      "Add resistances for hull reinforcement packages",
+      "Added modifier actions to create modifications from raw data",
+      "Show modification icon for modified modules",
+      "Take modifications in to account when deciding whether to issue a warning on a standard module",
+      "Fix hardpoint comparison DPS number when selecting an alternate module",
+      "Ensure that retrofit tab only shows changed modules",
+      "Fix import and export of ships with modifications, bump schema version to 4",
+      "Enable boost display even if power distributor is disabled",
+      "Calculate breakdown of ship offensive and defensive stats",
+      "Add 'Offence summary' and 'Defence summary' components",
+      "Add ability to import from companion API output through import feature",
+      "Add ability to import from companion API output through URL"
+    ]
+  }
+]

--- a/src/app/pages/ChangelogPage.jsx
+++ b/src/app/pages/ChangelogPage.jsx
@@ -31,7 +31,6 @@ export default class ChangelogPage extends Page {
         {announcements.map(a => (
           <div key={a.id} id={`v${a.version}`} className='changelog-entry'>
             <h2>{prefix}{a.version}</h2>
-            <h3>{a.text}</h3>
             <ul>
               {a.changes.map((change, i) => (
                 <li key={i}>{change}</li>
@@ -39,6 +38,7 @@ export default class ChangelogPage extends Page {
             </ul>
           </div>
         ))}
+        <p>Only versions since 4.0.9 are tracked, as there was a huge gap in the use of ChangeLog for several years.</p>
       </div>
     );
   }

--- a/src/app/pages/ChangelogPage.jsx
+++ b/src/app/pages/ChangelogPage.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Page from './Page';
+import announcements from '../data/announcements.json';
+
+/**
+ * Returns version prefix based on current site environment
+ */
+function getVersionPrefix() {
+  const host = window.location.hostname;
+  if (host.includes('alpha')) return 'Alpha v';
+  if (host.includes('beta')) return 'Beta v';
+  return 'v';
+}
+
+/**
+ * Changelog Page - renders version history from generated announcements data
+ */
+export default class ChangelogPage extends Page {
+
+  constructor(props) {
+    super(props);
+    this.state = { title: 'Changelog - Coriolis' };
+  }
+
+  renderPage() {
+    const prefix = getVersionPrefix();
+
+    return (
+      <div className='page changelog-page' style={{ padding: '2em', maxWidth: '800px', margin: '0 auto' }}>
+        <h1>Changelog</h1>
+        {announcements.map(a => (
+          <div key={a.id} id={`v${a.version}`} className='changelog-entry'>
+            <h2>{prefix}{a.version}</h2>
+            <h3>{a.text}</h3>
+            <ul>
+              {a.changes.map((change, i) => (
+                <li key={i}>{change}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    );
+  }
+}

--- a/src/less/app.less
+++ b/src/less/app.less
@@ -193,3 +193,162 @@ footer {
   padding: 10px;
   margin: 5px;
 }
+
+.announcement-banner-overlay {
+  position: fixed;
+  top: 0;
+  left: 285px;
+  right: 0;
+  z-index: 999;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.announcement-banner {
+  pointer-events: all;
+  background-color: @bg;
+  border: 1px solid @warning;
+  border-top: none;
+  padding: 0.6em 1.5em;
+  color: @warning;
+  font-size: 0.9em;
+  text-align: center;
+  animation: slide-down 0.3s ease-out;
+
+  &.slide-up {
+    animation: slide-up 0.3s ease-in forwards;
+  }
+}
+
+@keyframes slide-down {
+  from { transform: translateY(-100%); }
+  to { transform: translateY(0); }
+}
+
+@keyframes slide-up {
+  from { transform: translateY(0); }
+  to { transform: translateY(-100%); }
+}
+
+.announcement-banner-text {
+  flex: 1;
+}
+
+.announcement-banner-dismiss {
+  background: none;
+  border: none;
+  color: @primary-disabled;
+  font-size: 1.1em;
+  cursor: pointer;
+  padding: 0 0.5em;
+
+  &:hover {
+    color: @primary;
+  }
+}
+
+.announcement-menu {
+  min-width: 250px;
+  max-width: 350px;
+  white-space: normal;
+  position: absolute;
+  right: 0;
+  left: auto;
+}
+
+.announcement-item {
+  padding: 0.5em 1em;
+  color: @primary;
+  border-bottom: 1px solid @primary-disabled;
+  text-align: left;
+  font-size: 0.85em;
+  line-height: 1.3;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.pulse {
+  animation: pulse-glow 1.5s ease-in-out infinite;
+}
+
+.announcement-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.announcement-entry {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75em;
+  padding: 0.6em 0.5em;
+  border-bottom: 1px solid @primary-bg;
+  text-decoration: none;
+  color: @primary;
+  transition: background-color 0.15s;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background-color: @primary-bg;
+  }
+
+  &.latest {
+    color: @warning;
+  }
+}
+
+.announcement-version {
+  font-weight: bold;
+  white-space: nowrap;
+  min-width: 4.5em;
+}
+
+.announcement-text {
+  flex: 1;
+}
+
+.changelog-page {
+  h1 {
+    color: @warning;
+    text-transform: uppercase;
+    margin-bottom: 1.5em;
+  }
+}
+
+.changelog-entry {
+  margin-bottom: 2em;
+  padding-bottom: 1.5em;
+  border-bottom: 1px solid @primary-bg;
+
+  h2 {
+    color: @warning;
+    margin: 0 0 0.25em;
+  }
+
+  h3 {
+    color: @primary;
+    margin: 0 0 0.75em;
+    font-weight: normal;
+    font-style: italic;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1.5em;
+    color: @primary-disabled;
+
+    li {
+      margin-bottom: 0.3em;
+    }
+  }
+
+  &:last-child {
+    border-bottom: none;
+  }
+}

--- a/src/less/header.less
+++ b/src/less/header.less
@@ -51,6 +51,7 @@ header {
     position: relative;
     z-index: 1;
     cursor: default;
+    height: 100%;
 
     &.r {
       .menu-list {
@@ -68,6 +69,8 @@ header {
     height: 100%;
     z-index: 2;
     padding : 0 1em;
+    display: flex;
+    align-items: center;
     cursor: pointer;
     color: @warning;
     text-transform: uppercase;

--- a/src/less/icons.less
+++ b/src/less/icons.less
@@ -17,9 +17,14 @@
     height: 0.5em;
   }
 
+  &.md {
+    width: 1.65em;
+    height: 1.55em;
+  }
+
   &.lg {
-    width: 1.6em;
-    height: 1.5em;
+    width: 1.95em;
+    height: 1.85em;
   }
 
   &.xl {


### PR DESCRIPTION
## Summary
Complete overhaul of the announcement system.

## Changes
- Slide-down notification banner for newest update (auto-dismisses after 15s, marks as seen after 4s)
- Bell icon with pulse glow when unseen announcements exist
- Announcements modal (click bell) showing last 7 version entries with links to changelog
- New /changelog page showing full version history
- Announcements auto-generated from ChangeLog.md at build time (no manual editing needed)
- Unified header icon sizing (md for left nav, lg for right nav)
- Vertically centred nav items via flexbox

## How it works
1. Add entry to ChangeLog.md with version bump (already required for live promotion)
2. Build runs generate-announcements.js which parses ChangeLog.md into JSON
3. App loads from JSON — banner, modal, and changelog page all update automatically