### PR TITLE
Collapse build option icons into dropdown on tablet/mobile

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+#4.0.26
+  * Build Options Menu introduced on mobile devices to replace icons
 #4.0.25
   * Revamped Announcements and created Changelog page
 #4.0.24

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coriolis_shipyard",
-  "version": "4.0.25",
+  "version": "4.0.26",
   "repository": {
     "type": "git",
     "url": "https://github.com/EDCD/coriolis"

--- a/src/app/data/announcements.json
+++ b/src/app/data/announcements.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": 47,
+    "version": "4.0.25",
+    "text": "Revamped Announcements and created Changelog page",
+    "changes": [
+      "Revamped Announcements and created Changelog page"
+    ]
+  },
+  {
     "id": 46,
     "version": "4.0.24",
     "text": "Builds Button on Firefox fix when no builds saved",

--- a/src/app/pages/OutfittingPage.jsx
+++ b/src/app/pages/OutfittingPage.jsx
@@ -965,7 +965,7 @@ export default class OutfittingPage extends Page {
               <span style={{ textTransform: 'none', fontSize: '1.8em' }}>
                 a|
               </span>
-              <span className="build-action-label">{translate('rename')}</span>
+              <span className="build-action-label">{translate('rename build')}</span>
             </button>
             <button
               onClick={canReload && this._reloadBuild}
@@ -974,7 +974,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <Reload className="lg" />
-              <span className="build-action-label">{translate('reload')}</span>
+              <span className="build-action-label">{translate('reload page')}</span>
             </button>
             <button
               className={'danger'}
@@ -984,7 +984,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <Bin className="lg" />
-              <span className="build-action-label">{translate('delete')}</span>
+              <span className="build-action-label">{translate('delete build')}</span>
             </button>
             <button
               onClick={code && this._resetBuild}
@@ -993,7 +993,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <Switch className="lg" />
-              <span className="build-action-label">{translate('reset')}</span>
+              <span className="build-action-label">{translate('reset build')}</span>
             </button>
             <button
               onClick={buildName && this._exportBuild}
@@ -1002,7 +1002,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <Download className="lg" />
-              <span className="build-action-label">{translate('export')}</span>
+              <span className="build-action-label">{translate('export build')}</span>
             </button>
             <button
               onClick={this._inaraShoppingList}
@@ -1010,7 +1010,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <ShoppingIcon className="lg" />
-              <span className="build-action-label">{translate('stations')}</span>
+              <span className="build-action-label">{translate('stations that sell')}</span>
             </button>
             <button
               onClick={this._genShortlink}
@@ -1018,7 +1018,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <LinkIcon className="lg" />
-              <span className="build-action-label">{translate('shortlink')}</span>
+              <span className="build-action-label">{translate('get shortlink')}</span>
             </button>
             <button
               onClick={this._genShoppingList}
@@ -1026,7 +1026,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <MatIcon className="lg" />
-              <span className="build-action-label">{translate('materials')}</span>
+              <span className="build-action-label">{translate('materials needed')}</span>
             </button>
             <button
               className={(!Persist.getActiveCmdrLink() || !savedCode || !Persist.hasBuilds()) ? 'disabled' : ''}
@@ -1043,7 +1043,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <PersonIcon className="lg" />
-              <span className="build-action-label">{translate('save to CMDR')}</span>
+              <span className="build-action-label">{translate('save to CMDR-Coriolis')}</span>
             </button>
             </div>
             </div>

--- a/src/app/pages/OutfittingPage.jsx
+++ b/src/app/pages/OutfittingPage.jsx
@@ -153,7 +153,8 @@ export default class OutfittingPage extends Page {
       useResponsiveSummary,
       statBarCollapsed: false,
       outfittingCollapsed: false,
-      analysisCollapsed: false
+      analysisCollapsed: false,
+      buildActionsOpen: false
     };
   }
 
@@ -941,8 +942,8 @@ export default class OutfittingPage extends Page {
               placeholder={translate('Enter Name')}
               maxLength={50}
             />
-            <div className="build-actions">
             <button
+              className="build-action-save"
               onClick={canSave && this._saveBuild}
               disabled={!canSave}
               onMouseOver={termtip.bind(null, 'save')}
@@ -950,6 +951,11 @@ export default class OutfittingPage extends Page {
             >
               <FloppyDisk className="lg" />
             </button>
+            <div className="build-actions">
+            <button className="build-actions-toggle" onClick={() => this.setState({ buildActionsOpen: !this.state.buildActionsOpen })}>
+              {this.state.buildActionsOpen ? '▲ Build Options ▲' : '▼ Build Options ▼'}
+            </button>
+            <div className={cn('build-actions-list', { open: this.state.buildActionsOpen })}>
             <button
               onClick={canRename && this._renameBuild}
               disabled={!canRename}
@@ -959,6 +965,7 @@ export default class OutfittingPage extends Page {
               <span style={{ textTransform: 'none', fontSize: '1.8em' }}>
                 a|
               </span>
+              <span className="build-action-label">{translate('rename')}</span>
             </button>
             <button
               onClick={canReload && this._reloadBuild}
@@ -967,6 +974,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <Reload className="lg" />
+              <span className="build-action-label">{translate('reload')}</span>
             </button>
             <button
               className={'danger'}
@@ -976,6 +984,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <Bin className="lg" />
+              <span className="build-action-label">{translate('delete')}</span>
             </button>
             <button
               onClick={code && this._resetBuild}
@@ -984,6 +993,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <Switch className="lg" />
+              <span className="build-action-label">{translate('reset')}</span>
             </button>
             <button
               onClick={buildName && this._exportBuild}
@@ -992,6 +1002,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <Download className="lg" />
+              <span className="build-action-label">{translate('export')}</span>
             </button>
             <button
               onClick={this._inaraShoppingList}
@@ -999,6 +1010,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <ShoppingIcon className="lg" />
+              <span className="build-action-label">{translate('stations')}</span>
             </button>
             <button
               onClick={this._genShortlink}
@@ -1006,6 +1018,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <LinkIcon className="lg" />
+              <span className="build-action-label">{translate('shortlink')}</span>
             </button>
             <button
               onClick={this._genShoppingList}
@@ -1013,6 +1026,7 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <MatIcon className="lg" />
+              <span className="build-action-label">{translate('materials')}</span>
             </button>
             <button
               className={(!Persist.getActiveCmdrLink() || !savedCode || !Persist.hasBuilds()) ? 'disabled' : ''}
@@ -1029,7 +1043,9 @@ export default class OutfittingPage extends Page {
               onMouseOut={hide}
             >
               <PersonIcon className="lg" />
+              <span className="build-action-label">{translate('save to CMDR')}</span>
             </button>
+            </div>
             </div>
           </div>
         </div>

--- a/src/less/app.less
+++ b/src/less/app.less
@@ -350,6 +350,8 @@ footer {
 
   &:last-child {
     border-bottom: none;
+  }
+}
 
 // Build actions responsive dropdown
 .build-actions {

--- a/src/less/app.less
+++ b/src/less/app.less
@@ -350,5 +350,99 @@ footer {
 
   &:last-child {
     border-bottom: none;
+
+// Build actions responsive dropdown
+.build-actions {
+  position: relative;
+}
+
+.build-action-label {
+  display: none;
+}
+
+.build-actions-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: @warning;
+  cursor: pointer;
+  padding: 0.3em 0.8em;
+  font-size: 0.9em;
+  line-height: 1.3em;
+
+  &:hover {
+    color: lighten(@warning, 15%);
+  }
+}
+
+@media only screen and (max-width: 1024px) {
+  #build {
+    position: relative;
+  }
+
+  #build input {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto;
+  }
+
+  .build-action-save {
+    flex: 0 0 auto;
+    margin-left: 0.3em;
+  }
+
+  #build .build-actions {
+    position: static;
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    margin-top: 0.3em;
+  }
+
+  .build-actions-toggle {
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+
+  .build-actions-list {
+    display: none;
+    width: 100%;
+    flex-direction: column;
+    gap: 0;
+    padding: 0;
+    margin-top: 0.3em;
+    background-color: @bg;
+    border: 1px solid @primary-disabled;
+    box-sizing: border-box;
+  }
+
+  .build-actions-list.open {
+    display: flex;
+  }
+
+  #build .build-actions-list button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6em;
+    width: 100%;
+    min-height: 3em;
+    padding: 1em 0.8em;
+    text-align: center;
+    border: none;
+    border-bottom: 1px solid @primary-bg;
+    background: none;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .build-actions-list .build-action-label {
+    display: inline;
+    font-size: 1.2em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
   }
 }


### PR DESCRIPTION
On screens 1024px wide and smaller, the build option icons (rename, reload, delete, reset, export, shopping list, shortlink, shopping mats, save to CMDR) now collapse into a 'Build Options' dropdown toggle below the build name bar.

- Save icon stays appended to the name input on all screen sizes.
- Toggle matches the stat bar text-toggle style (orange text, hover lightens, no border/background) with triangle indicators showing expand/collapse state.
- Dropdown opens directly below the toggle, above the responsive/classic view toggle, without altering the toggle button appearance.