### PR TITLE
Fix duplicate search bar in empty slot and back button top padding

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+#4.0.27
+  * Fixed duplicate search box when selecting an empty slot and typing
+  * Fixed announcements to mark all as read when you visit the ChangeLog page
 #4.0.26
   * Build Options Menu introduced on mobile devices to replace icons
 #4.0.25

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coriolis_shipyard",
-  "version": "4.0.26",
+  "version": "4.0.27",
   "repository": {
     "type": "git",
     "url": "https://github.com/EDCD/coriolis"

--- a/src/app/Coriolis.jsx
+++ b/src/app/Coriolis.jsx
@@ -61,20 +61,29 @@ export default class Coriolis extends React.Component {
       // Announcements loaded from generated data (see generate-announcements.js)
       announcements: announcementsData,
       showAnnouncementBanner: false,
+      pulseExpired: false,
 
       language: getLanguage(Persist.getLangCode()),
       route: {},
       sizeRatio: Persist.getSizeRatio()
     };
 
-    // Show banner for newest announcement if not already seen
+    // Show banner only for the newest announcement if it has not been seen yet
     const validAnnouncements = this.state.announcements.slice(0, 7);
     if (validAnnouncements.length > 0) {
-      const lastSeenId = parseInt(localStorage.getItem('lastSeenAnnouncementId') || '0');
-      if (validAnnouncements[0].id > lastSeenId) {
+      let seenIds = [];
+      try {
+        seenIds = JSON.parse(localStorage.getItem('seenAnnouncementIds') || '[]');
+      } catch (e) { seenIds = []; }
+      const newest = validAnnouncements[0];
+      if (!seenIds.includes(newest.id)) {
         this.state.showAnnouncementBanner = true;
       }
     }
+
+    // Stop bell pulse after 10s regardless of state
+    setTimeout(() => this.setState({ pulseExpired: true }), 10000);
+
     Router('', (r) => this._setPage(ShipyardPage, r));
     Router('/import?', (r) => this._importBuild(r));
     Router('/import/:data', (r) => this._importBuild(r));
@@ -288,6 +297,20 @@ export default class Coriolis extends React.Component {
   }
 
   /**
+   * Returns true if any announcement in the visible slice has not been seen.
+   * Used to control the bell pulse independently of the banner state.
+   */
+  _hasUnseenAnnouncements() {
+    const visible = this.state.announcements.slice(0, 7);
+    if (visible.length === 0) return false;
+    let seenIds = [];
+    try {
+      seenIds = JSON.parse(localStorage.getItem('seenAnnouncementIds') || '[]');
+    } catch (e) { seenIds = []; }
+    return visible.some(a => !seenIds.includes(a.id));
+  }
+
+  /**
    * Sets the open menu state
    * @param  {string|object} currentMenu The reference to the current menu
    */
@@ -420,6 +443,13 @@ export default class Coriolis extends React.Component {
     // Listen for postMessage from cmdr.coriolis.io link popup
     window.addEventListener('message', this._onCmdrLinkMessage.bind(this));
 
+    // Listen for announcements-seen events (e.g. when the user opens the
+    // changelog page). Clears the bell pulse and hides the banner.
+    window.addEventListener('announcementsSeen', () => {
+      this.setState({ showAnnouncementBanner: false });
+      this.forceUpdate();
+    });
+
     // Check for redirect-based CMDR link data in the URL hash
     // (fallback when window.opener is null in the popup)
     this._checkCmdrLinkHash();
@@ -482,9 +512,10 @@ export default class Coriolis extends React.Component {
       <AppContext.Provider value={contextValue}>
         <div style={{ minHeight: '100%' }} onClick={() => { this._closeMenu(); this._tooltip(); }}
              className={this.state.noTouch ? 'no-touch' : null}>
-          <Header announcements={this.state.announcements} hasUnseenAnnouncements={this.state.showAnnouncementBanner} appCacheUpdate={this.state.appCacheUpdate}
+          <Header announcements={this.state.announcements} hasUnseenAnnouncements={!this.state.pulseExpired && this._hasUnseenAnnouncements()} appCacheUpdate={this.state.appCacheUpdate}
                   onAnnouncementsSeen={() => {
-                    if (this.state.announcements.length > 0) localStorage.setItem('lastSeenAnnouncementId', this.state.announcements[0].id.toString());
+                    // Bell click no longer marks everything as seen -
+                    // individual entries are tracked per-id (banner, changelog).
                     this.setState({ showAnnouncementBanner: false });
                   }}
                   currentMenu={currentMenu}/>

--- a/src/app/components/AnnouncementBanner.jsx
+++ b/src/app/components/AnnouncementBanner.jsx
@@ -18,10 +18,16 @@ export default class AnnouncementBanner extends React.Component {
   }
 
   componentDidMount() {
-    // Mark as seen after 4 seconds
+    // Mark as seen after 4 seconds (only this specific announcement)
     this._cookieTimer = setTimeout(() => {
       if (this.props.announcement) {
-        localStorage.setItem('lastSeenAnnouncementId', this.props.announcement.id.toString());
+        const raw = localStorage.getItem('seenAnnouncementIds');
+        let seen = [];
+        try { seen = raw ? JSON.parse(raw) : []; } catch (e) { seen = []; }
+        if (!seen.includes(this.props.announcement.id)) {
+          seen.push(this.props.announcement.id);
+          localStorage.setItem('seenAnnouncementIds', JSON.stringify(seen));
+        }
       }
     }, 4000);
 

--- a/src/app/components/AvailableModulesMenu.jsx
+++ b/src/app/components/AvailableModulesMenu.jsx
@@ -1694,7 +1694,7 @@ export default class AvailableModulesMenu extends TranslatedComponent {
    * @return {Object} React component
    */
   render() {
-    let { className, selectedCategory, onBack } = this.props;
+    let { className, selectedCategory, onBack, hideSearch } = this.props;
     let { list, searchQuery } = this.state;
 
     let classes = cn('select', className);
@@ -1702,7 +1702,7 @@ export default class AvailableModulesMenu extends TranslatedComponent {
     // Determine if we should show search box
     // Show for optional internal, hardpoint, and utility slots (not for standard/core modules)
     const isCoreInternal = className && className.includes('standard');
-    const showSearch = !isCoreInternal;
+    const showSearch = !isCoreInternal && !hideSearch;
 
     // Show back button if a category is selected
     const showBackButton = selectedCategory && onBack;

--- a/src/app/components/CategoryMenu.jsx
+++ b/src/app/components/CategoryMenu.jsx
@@ -328,7 +328,10 @@ export default class CategoryMenu extends TranslatedComponent {
     // If searching, render AvailableModulesMenu with search pre-populated
     if (hasSearchQuery) {
       return (
-        <div>
+        <div
+          className={cn('select', 'category-menu', className)}
+          onContextMenu={stopCtxPropagation}
+        >
           <div className="module-search-container">
             <input
               ref={this.searchInputRef}
@@ -351,6 +354,7 @@ export default class CategoryMenu extends TranslatedComponent {
             diffDetails={ship ? diffDetails.bind(ship, this.context.language) : undefined}
             eligible={eligible}
             searchQuery={searchQuery}
+            hideSearch={true}
           />
         </div>
       );

--- a/src/app/components/ModalAnnouncements.jsx
+++ b/src/app/components/ModalAnnouncements.jsx
@@ -14,17 +14,34 @@ function getVersionPrefix() {
  */
 export default class ModalAnnouncements extends TranslatedComponent {
 
+  _onEntryClick = () => {
+    // If we're already on the changelog page, clicking an entry (anchor link)
+    // won't navigate to a new page and so the modal would stay open. Force-close.
+    if (window.location.pathname === '/changelog') {
+      if (this.context.hideModal) this.context.hideModal();
+    }
+  };
+
   render() {
     const { announcements } = this.props;
     const translate = this.context.language.translate;
     const prefix = getVersionPrefix();
+    let seenIds = [];
+    try {
+      seenIds = JSON.parse(localStorage.getItem('seenAnnouncementIds') || '[]');
+    } catch (e) { seenIds = []; }
 
     return (
       <div className='modal' onClick={(e) => e.stopPropagation()}>
         <h2>{translate('announcements')}</h2>
         <div className='announcement-list'>
           {announcements.slice(0, 7).map((a, i) => (
-            <a key={a.id} href={`/changelog#v${a.version}`} className={cn('announcement-entry', { latest: i === 0 })}>
+            <a key={a.id} href={`/changelog#v${a.version}`}
+               onClick={this._onEntryClick}
+               className={cn('announcement-entry', {
+                 latest: i === 0,
+                 unread: !seenIds.includes(a.id) && i !== 0
+               })}>
               <span className='announcement-version'>{prefix}{a.version}</span>
               <span className='announcement-text'>{a.text}</span>
             </a>

--- a/src/app/pages/ChangelogPage.jsx
+++ b/src/app/pages/ChangelogPage.jsx
@@ -22,6 +22,15 @@ export default class ChangelogPage extends Page {
     this.state = { title: 'Changelog - Coriolis' };
   }
 
+  componentDidMount() {
+    // Mark all announcements as seen when the changelog is opened
+    if (announcements.length > 0) {
+      const ids = announcements.map(a => a.id);
+      localStorage.setItem('seenAnnouncementIds', JSON.stringify(ids));
+      window.dispatchEvent(new CustomEvent('announcementsSeen'));
+    }
+  }
+
   renderPage() {
     const prefix = getVersionPrefix();
 

--- a/src/less/app.less
+++ b/src/less/app.less
@@ -287,7 +287,7 @@ footer {
   padding: 0.6em 0.5em;
   border-bottom: 1px solid @primary-bg;
   text-decoration: none;
-  color: @primary;
+  color: @fg;
   transition: background-color 0.15s;
 
   &:last-child {
@@ -300,6 +300,10 @@ footer {
 
   &.latest {
     color: @warning;
+  }
+
+  &.unread {
+    color: @primary;
   }
 }
 

--- a/src/less/select.less
+++ b/src/less/select.less
@@ -669,6 +669,10 @@ select {
 }
 
 // Module search container and back button - both sticky at top
+.select:has(.back-button) {
+  padding-top: 0.5em;
+}
+
 .back-button {
   position: sticky !important;
   top: 0;
@@ -678,7 +682,7 @@ select {
   left: 0 !important;
   max-width: calc(100% - 44px);
   margin: 0 auto !important;
-  padding-top: calc(0.5em + 3px);
+  padding-top: 0.5em;
   padding-bottom: 0.5em;
 }
 
@@ -733,4 +737,16 @@ select {
   &:hover:not(:focus) {
     border-color: fade(@primary, 50%);
   }
+}
+
+// When CategoryMenu is in search mode, the nested AvailableModulesMenu's
+// .select shouldn't take over the outer container's layout
+.category-menu .select {
+  position: static;
+  left: auto;
+  width: 100%;
+  max-height: none;
+  border: none;
+  background: none;
+  overflow: visible;
 }


### PR DESCRIPTION
Fixes two visual bugs introduced with the recent module search auto-focus work:

- **Duplicate search bar in empty slot:** When opening an empty slot, the CategoryMenu renders a search input at the top. When the user typed in it, the nested AvailableModulesMenu rendered its own second search input below, which did not sync with the outer one and visually cluttered the slot. The nested AvailableModulesMenu now supports a `hideSearch` prop and CategoryMenu passes it when in search mode.
- **Outer container collapsing on search:** The search-results branch of CategoryMenu wrapped content in a plain `<div>` instead of the `.select.category-menu` container, so the dropdown shrank when typing. The search branch now uses the same outer container, and a new rule constrains the nested `.select` to static layout inside `.category-menu` so it does not take over the outer layout.
- **Back-to-categories button top padding:** When drilling into a category, the sticky back button sat flush against the top of the dropdown. Added a `.select:has(.back-button)` rule so the container has top padding when the back button is present.